### PR TITLE
Fix porte dropdown layering

### DIFF
--- a/frontend/src/views/Produtos.tsx
+++ b/frontend/src/views/Produtos.tsx
@@ -29,6 +29,10 @@ type PorteSelectOption = {
 };
 
 const porteSelectStyles: StylesConfig<PorteSelectOption, true> = {
+  menuPortal: base => ({
+    ...base,
+    zIndex: 9999,
+  }),
   control: (base, state) => ({
     ...base,
     borderRadius: 12,
@@ -76,6 +80,8 @@ const porteSelectStyles: StylesConfig<PorteSelectOption, true> = {
     ...base,
     borderRadius: 12,
     padding: 0,
+    maxHeight: "unset",
+    overflowY: "visible",
   }),
   option: (base, state) => ({
     ...base,
@@ -376,6 +382,8 @@ export default function Produtos() {
               isMulti
               isDisabled={opcoesCarregando || !porteSelectOptions.length}
               isLoading={opcoesCarregando}
+              menuPortalTarget={document.body}
+              menuPosition="fixed"
               value={selectedPorteOptions}
               onChange={handlePorteChange}
               options={porteSelectOptions}


### PR DESCRIPTION
## Summary
- add a menuPortal style to the porte Select so its menu can render above other panels
- render the porte menu in a fixed-position portal to avoid clipping within the products panel
- remove the porte dropdown menu max-height so the option list no longer shows an unnecessary scrollbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d338f85acc832da2eecf97aace6f21