### PR TITLE
Add faixa etaria options to product management

### DIFF
--- a/backend/src/PremieRpet.Shop.Api/Controllers/ProdutosController.cs
+++ b/backend/src/PremieRpet.Shop.Api/Controllers/ProdutosController.cs
@@ -30,6 +30,11 @@ public class ProdutosController(IProdutoService svc) : ControllerBase
     public async Task<ActionResult<IReadOnlyList<ProdutoOpcaoDto>>> ListarTiposProduto(CancellationToken ct)
         => Ok(await svc.ListarTiposProdutoAsync(ct));
 
+    [HttpGet("faixas-etarias")]
+    [Authorize]
+    public async Task<ActionResult<IReadOnlyList<ProdutoOpcaoDto>>> ListarFaixasEtarias(CancellationToken ct)
+        => Ok(await svc.ListarFaixasEtariasAsync(ct));
+
     [HttpGet("{codigo}")]
     [Authorize("Admin")]
     public async Task<ActionResult<ProdutoDto?>> Get(string codigo, CancellationToken ct)

--- a/backend/src/PremieRpet.Shop.Application/DTOs/ProdutoCreateUpdateDto.cs
+++ b/backend/src/PremieRpet.Shop.Application/DTOs/ProdutoCreateUpdateDto.cs
@@ -11,5 +11,6 @@ public record ProdutoCreateUpdateDto(
     Guid EspecieOpcaoId,
     IReadOnlyList<Guid> PorteOpcaoIds,
     Guid TipoProdutoOpcaoId,
+    Guid FaixaEtariaOpcaoId,
     decimal Preco,
     int QuantidadeMinimaDeCompra);

--- a/backend/src/PremieRpet.Shop.Application/DTOs/ProdutoDto.cs
+++ b/backend/src/PremieRpet.Shop.Application/DTOs/ProdutoDto.cs
@@ -15,5 +15,7 @@ public record ProdutoDto(
     IReadOnlyList<string> PorteNomes,
     Guid TipoProdutoOpcaoId,
     string TipoProdutoNome,
+    Guid FaixaEtariaOpcaoId,
+    string FaixaEtariaNome,
     decimal Preco,
     int QuantidadeMinimaDeCompra);

--- a/backend/src/PremieRpet.Shop.Application/Interfaces/Repositories/IProdutoRepository.cs
+++ b/backend/src/PremieRpet.Shop.Application/Interfaces/Repositories/IProdutoRepository.cs
@@ -14,8 +14,10 @@ public interface IProdutoRepository
     Task<IReadOnlyList<ProdutoEspecieOpcao>> ListarEspeciesAsync(CancellationToken ct);
     Task<IReadOnlyList<ProdutoPorteOpcao>> ListarPortesAsync(CancellationToken ct);
     Task<IReadOnlyList<ProdutoTipoOpcao>> ListarTiposProdutoAsync(CancellationToken ct);
+    Task<IReadOnlyList<ProdutoFaixaEtariaOpcao>> ListarFaixasEtariasAsync(CancellationToken ct);
     Task<ProdutoEspecieOpcao?> ObterEspecieAsync(Guid id, CancellationToken ct);
     Task<ProdutoTipoOpcao?> ObterTipoProdutoAsync(Guid id, CancellationToken ct);
+    Task<ProdutoFaixaEtariaOpcao?> ObterFaixaEtariaAsync(Guid id, CancellationToken ct);
     Task<IReadOnlyList<ProdutoPorteOpcao>> ObterPortesAsync(IEnumerable<Guid> ids, CancellationToken ct);
     IQueryable<Produto> Query();
 }

--- a/backend/src/PremieRpet.Shop.Application/Interfaces/UseCases/IProdutoService.cs
+++ b/backend/src/PremieRpet.Shop.Application/Interfaces/UseCases/IProdutoService.cs
@@ -13,4 +13,5 @@ public interface IProdutoService
     Task<IReadOnlyList<ProdutoOpcaoDto>> ListarEspeciesAsync(CancellationToken ct);
     Task<IReadOnlyList<ProdutoOpcaoDto>> ListarPortesAsync(CancellationToken ct);
     Task<IReadOnlyList<ProdutoOpcaoDto>> ListarTiposProdutoAsync(CancellationToken ct);
+    Task<IReadOnlyList<ProdutoOpcaoDto>> ListarFaixasEtariasAsync(CancellationToken ct);
 }

--- a/backend/src/PremieRpet.Shop.Application/UseCases/ProdutoService.cs
+++ b/backend/src/PremieRpet.Shop.Application/UseCases/ProdutoService.cs
@@ -38,6 +38,8 @@ public sealed class ProdutoService : IProdutoService
             porteNomes,
             p.TipoProdutoOpcaoId,
             p.TipoProdutoOpcao?.Nome ?? string.Empty,
+            p.FaixaEtariaOpcaoId,
+            p.FaixaEtariaOpcao?.Nome ?? string.Empty,
             p.Preco,
             p.QuantidadeMinimaDeCompra);
     }
@@ -58,6 +60,8 @@ public sealed class ProdutoService : IProdutoService
             ?? throw new InvalidOperationException("Espécie inválida.");
         var tipoProduto = await _repo.ObterTipoProdutoAsync(dto.TipoProdutoOpcaoId, ct)
             ?? throw new InvalidOperationException("Tipo de produto inválido.");
+        var faixaEtaria = await _repo.ObterFaixaEtariaAsync(dto.FaixaEtariaOpcaoId, ct)
+            ?? throw new InvalidOperationException("Faixa etária inválida.");
 
         var porteIds = NormalizarPortes(dto.PorteOpcaoIds);
         var portes = await _repo.ObterPortesAsync(porteIds, ct);
@@ -73,6 +77,7 @@ public sealed class ProdutoService : IProdutoService
             Sabores = dto.Sabores,
             EspecieOpcaoId = especie.Id,
             TipoProdutoOpcaoId = tipoProduto.Id,
+            FaixaEtariaOpcaoId = faixaEtaria.Id,
             Preco = dto.Preco,
             QuantidadeMinimaDeCompra = Math.Max(1, dto.QuantidadeMinimaDeCompra),
             Portes = portes.Select(p => new ProdutoPorte { PorteOpcaoId = p.Id }).ToList()
@@ -117,6 +122,11 @@ public sealed class ProdutoService : IProdutoService
             .Select(o => new ProdutoOpcaoDto(o.Id, o.Nome))
             .ToList();
 
+    public async Task<IReadOnlyList<ProdutoOpcaoDto>> ListarFaixasEtariasAsync(CancellationToken ct)
+        => (await _repo.ListarFaixasEtariasAsync(ct))
+            .Select(o => new ProdutoOpcaoDto(o.Id, o.Nome))
+            .ToList();
+
     public async Task UpdateAsync(string codigo, ProdutoCreateUpdateDto dto, CancellationToken ct)
     {
         var prod = await _repo.GetAsync(codigo, ct) ?? throw new InvalidOperationException("Produto não encontrado.");
@@ -124,6 +134,8 @@ public sealed class ProdutoService : IProdutoService
             ?? throw new InvalidOperationException("Espécie inválida.");
         var tipoProduto = await _repo.ObterTipoProdutoAsync(dto.TipoProdutoOpcaoId, ct)
             ?? throw new InvalidOperationException("Tipo de produto inválido.");
+        var faixaEtaria = await _repo.ObterFaixaEtariaAsync(dto.FaixaEtariaOpcaoId, ct)
+            ?? throw new InvalidOperationException("Faixa etária inválida.");
 
         var porteIds = NormalizarPortes(dto.PorteOpcaoIds);
         var portes = await _repo.ObterPortesAsync(porteIds, ct);
@@ -136,6 +148,7 @@ public sealed class ProdutoService : IProdutoService
         prod.Sabores = dto.Sabores;
         prod.EspecieOpcaoId = especie.Id;
         prod.TipoProdutoOpcaoId = tipoProduto.Id;
+        prod.FaixaEtariaOpcaoId = faixaEtaria.Id;
         prod.Preco = dto.Preco;
         prod.QuantidadeMinimaDeCompra = Math.Max(1, dto.QuantidadeMinimaDeCompra);
 

--- a/backend/src/PremieRpet.Shop.Domain/Entities/Produto.cs
+++ b/backend/src/PremieRpet.Shop.Domain/Entities/Produto.cs
@@ -15,6 +15,8 @@ public sealed class Produto
     public ProdutoEspecieOpcao? EspecieOpcao { get; set; }
     public Guid TipoProdutoOpcaoId { get; set; }
     public ProdutoTipoOpcao? TipoProdutoOpcao { get; set; }
+    public Guid FaixaEtariaOpcaoId { get; set; }
+    public ProdutoFaixaEtariaOpcao? FaixaEtariaOpcao { get; set; }
     public ICollection<ProdutoPorte> Portes { get; set; } = new List<ProdutoPorte>();
     public required decimal Preco { get; set; }
     public int QuantidadeMinimaDeCompra { get; set; } = 1;

--- a/backend/src/PremieRpet.Shop.Domain/Entities/ProdutoFaixaEtariaOpcao.cs
+++ b/backend/src/PremieRpet.Shop.Domain/Entities/ProdutoFaixaEtariaOpcao.cs
@@ -1,0 +1,8 @@
+namespace PremieRpet.Shop.Domain.Entities;
+
+public sealed class ProdutoFaixaEtariaOpcao
+{
+    public Guid Id { get; set; }
+    public required string Nome { get; set; }
+    public ICollection<Produto> Produtos { get; set; } = new List<Produto>();
+}

--- a/backend/src/PremieRpet.Shop.Infrastructure/Repositories/ProdutoRepository.cs
+++ b/backend/src/PremieRpet.Shop.Infrastructure/Repositories/ProdutoRepository.cs
@@ -46,11 +46,19 @@ public sealed class ProdutoRepository : IProdutoRepository
             .OrderBy(o => o.Nome)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyList<ProdutoFaixaEtariaOpcao>> ListarFaixasEtariasAsync(CancellationToken ct)
+        => await _db.ProdutoFaixaEtariaOpcoes
+            .OrderBy(o => o.Nome)
+            .ToListAsync(ct);
+
     public async Task<ProdutoEspecieOpcao?> ObterEspecieAsync(Guid id, CancellationToken ct)
         => await _db.ProdutoEspecieOpcoes.FirstOrDefaultAsync(o => o.Id == id, ct);
 
     public async Task<ProdutoTipoOpcao?> ObterTipoProdutoAsync(Guid id, CancellationToken ct)
         => await _db.ProdutoTipoOpcoes.FirstOrDefaultAsync(o => o.Id == id, ct);
+
+    public async Task<ProdutoFaixaEtariaOpcao?> ObterFaixaEtariaAsync(Guid id, CancellationToken ct)
+        => await _db.ProdutoFaixaEtariaOpcoes.FirstOrDefaultAsync(o => o.Id == id, ct);
 
     public async Task<IReadOnlyList<ProdutoPorteOpcao>> ObterPortesAsync(IEnumerable<Guid> ids, CancellationToken ct)
     {
@@ -67,6 +75,7 @@ public sealed class ProdutoRepository : IProdutoRepository
         => _db.Produtos
             .Include(p => p.EspecieOpcao)
             .Include(p => p.TipoProdutoOpcao)
+            .Include(p => p.FaixaEtariaOpcao)
             .Include(p => p.Portes)
                 .ThenInclude(pp => pp.PorteOpcao)
             .AsQueryable();

--- a/backend/src/PremieRpet.Shop.Infrastructure/ShopDbContext.cs
+++ b/backend/src/PremieRpet.Shop.Infrastructure/ShopDbContext.cs
@@ -12,6 +12,7 @@ public sealed class ShopDbContext : DbContext
     public DbSet<ProdutoEspecieOpcao> ProdutoEspecieOpcoes => Set<ProdutoEspecieOpcao>();
     public DbSet<ProdutoPorteOpcao> ProdutoPorteOpcoes => Set<ProdutoPorteOpcao>();
     public DbSet<ProdutoTipoOpcao> ProdutoTipoOpcoes => Set<ProdutoTipoOpcao>();
+    public DbSet<ProdutoFaixaEtariaOpcao> ProdutoFaixaEtariaOpcoes => Set<ProdutoFaixaEtariaOpcao>();
     public DbSet<ProdutoPorte> ProdutoPortes => Set<ProdutoPorte>();
 
     public ShopDbContext(DbContextOptions<ShopDbContext> options) : base(options) { }
@@ -26,6 +27,7 @@ public sealed class ShopDbContext : DbContext
             e.Property(p => p.Descricao).HasMaxLength(256).IsRequired();
             e.Property(p => p.EspecieOpcaoId).IsRequired();
             e.Property(p => p.TipoProdutoOpcaoId).IsRequired();
+            e.Property(p => p.FaixaEtariaOpcaoId).IsRequired();
             e.Property(x => x.Peso).HasColumnType("decimal(18,4)");
             e.Property(x => x.Preco).HasColumnType("numeric(18,2)");
             e.Property(p => p.TipoPeso).HasColumnType("int");
@@ -39,6 +41,11 @@ public sealed class ShopDbContext : DbContext
             e.HasOne(p => p.TipoProdutoOpcao)
                 .WithMany(t => t.Produtos)
                 .HasForeignKey(p => p.TipoProdutoOpcaoId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            e.HasOne(p => p.FaixaEtariaOpcao)
+                .WithMany(f => f.Produtos)
+                .HasForeignKey(p => p.FaixaEtariaOpcaoId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
 
@@ -90,6 +97,20 @@ public sealed class ShopDbContext : DbContext
                 new ProdutoTipoOpcao { Id = Guid.Parse("5006ea85-e9b1-4185-ba5d-08cecbcaf998"), Nome = "Alimento Seco" },
                 new ProdutoTipoOpcao { Id = Guid.Parse("1e2e7740-36e1-4961-96a5-308c6e48b457"), Nome = "Cookie" },
                 new ProdutoTipoOpcao { Id = Guid.Parse("601026f0-606b-4f67-bad7-eaefa16c62c6"), Nome = "Alimento Úmido" }
+            );
+        });
+
+        b.Entity<ProdutoFaixaEtariaOpcao>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.Property(x => x.Nome).HasMaxLength(64).IsRequired();
+            e.HasIndex(x => x.Nome).IsUnique();
+
+            e.HasData(
+                new ProdutoFaixaEtariaOpcao { Id = Guid.Parse("8e29fa8e-f3bd-4f4a-a73c-82009fcb2998"), Nome = "Filhote" },
+                new ProdutoFaixaEtariaOpcao { Id = Guid.Parse("1bb02ce7-54c9-43c6-9d28-68c9323fc86e"), Nome = "Adulto" },
+                new ProdutoFaixaEtariaOpcao { Id = Guid.Parse("d815602e-b739-497c-bb92-2ff27c51a638"), Nome = "Senior" },
+                new ProdutoFaixaEtariaOpcao { Id = Guid.Parse("87ba6774-1929-4ada-97ec-385fc846ab51"), Nome = "Todas" }
             );
         });
 

--- a/frontend/src/cart/types.ts
+++ b/frontend/src/cart/types.ts
@@ -10,6 +10,8 @@ export type Produto = {
   porteNomes: string[];
   tipoProdutoOpcaoId: string;
   tipoProdutoNome: string;
+  faixaEtariaOpcaoId: string;
+  faixaEtariaNome: string;
   preco: number;
   quantidadeMinimaDeCompra: number; // UNIDADES
 };

--- a/frontend/src/views/Catalogo.tsx
+++ b/frontend/src/views/Catalogo.tsx
@@ -28,6 +28,7 @@ export default function Catalogo() {
               )}
             </div>
             <p className="text-sm text-gray-500 mt-1">{p.sabores}</p>
+            <p className="text-xs text-indigo-600 mt-1 font-medium">Faixa etária: {p.faixaEtariaNome}</p>
             <p className="mt-2">R$ {p.preco.toFixed(2)}</p>
 
             <button

--- a/frontend/src/views/Produtos.tsx
+++ b/frontend/src/views/Produtos.tsx
@@ -14,6 +14,8 @@ type Produto = {
   porteNomes: string[];
   tipoProdutoOpcaoId: string;
   tipoProdutoNome: string;
+  faixaEtariaOpcaoId: string;
+  faixaEtariaNome: string;
   preco: number;
   quantidadeMinimaDeCompra: number;
 };
@@ -116,6 +118,7 @@ export default function Produtos() {
   const [especies, setEspecies] = useState<ProdutoOpcao[]>([]);
   const [porteOpcoes, setPorteOpcoes] = useState<ProdutoOpcao[]>([]);
   const [tiposProduto, setTiposProduto] = useState<ProdutoOpcao[]>([]);
+  const [faixasEtarias, setFaixasEtarias] = useState<ProdutoOpcao[]>([]);
   const [produtos, setProdutos] = useState<Produto[]>([]);
   const [codigo, setCodigo] = useState("");
   const [descricao, setDescricao] = useState("");
@@ -125,6 +128,7 @@ export default function Produtos() {
   const [especieId, setEspecieId] = useState("");
   const [porteIds, setPorteIds] = useState<string[]>([]);
   const [tipoProdutoId, setTipoProdutoId] = useState("");
+  const [faixaEtariaId, setFaixaEtariaId] = useState("");
   const [preco, setPreco] = useState("0");
   const [quantidadeMinimaDeCompra, setQuantidadeMinimaDeCompra] = useState("1");
   const [opcoesCarregando, setOpcoesCarregando] = useState(true);
@@ -163,14 +167,16 @@ export default function Produtos() {
   const loadOpcoes = async () => {
     try {
       setOpcoesCarregando(true);
-      const [especiesResp, portesResp, tiposResp] = await Promise.all([
+      const [especiesResp, portesResp, tiposResp, faixasResp] = await Promise.all([
         api.get<ProdutoOpcao[]>("/produtos/especies"),
         api.get<ProdutoOpcao[]>("/produtos/portes"),
         api.get<ProdutoOpcao[]>("/produtos/tipos-produto"),
+        api.get<ProdutoOpcao[]>("/produtos/faixas-etarias"),
       ]);
       setEspecies(especiesResp.data);
       setPorteOpcoes(portesResp.data);
       setTiposProduto(tiposResp.data);
+      setFaixasEtarias(faixasResp.data);
     } finally {
       setOpcoesCarregando(false);
     }
@@ -193,6 +199,13 @@ export default function Produtos() {
       return tiposProduto.some(opcao => opcao.id === prev) ? prev : tiposProduto[0].id;
     });
   }, [tiposProduto]);
+
+  useEffect(() => {
+    setFaixaEtariaId(prev => {
+      if (!faixasEtarias.length) return "";
+      return faixasEtarias.some(opcao => opcao.id === prev) ? prev : faixasEtarias[0].id;
+    });
+  }, [faixasEtarias]);
 
   useEffect(() => {
     setPorteIds(prev => {
@@ -219,7 +232,8 @@ export default function Produtos() {
   const salvar = async () => {
     const especieSelecionada = especieId || especies[0]?.id || "";
     const tipoSelecionado = tipoProdutoId || tiposProduto[0]?.id || "";
-    if (!especieSelecionada || !tipoSelecionado) return;
+    const faixaSelecionada = faixaEtariaId || faixasEtarias[0]?.id || "";
+    if (!especieSelecionada || !tipoSelecionado || !faixaSelecionada) return;
 
     const dto = {
       descricao,
@@ -229,6 +243,7 @@ export default function Produtos() {
       especieOpcaoId: especieSelecionada,
       porteOpcaoIds: porteIds,
       tipoProdutoOpcaoId: tipoSelecionado,
+      faixaEtariaOpcaoId: faixaSelecionada,
       preco: parseDecimalInput(preco),
       quantidadeMinimaDeCompra: Math.max(1, parseIntegerInput(quantidadeMinimaDeCompra)),
     };
@@ -241,6 +256,7 @@ export default function Produtos() {
     setEspecieId(especies[0]?.id ?? "");
     setPorteIds([]);
     setTipoProdutoId(tiposProduto[0]?.id ?? "");
+    setFaixaEtariaId(faixasEtarias[0]?.id ?? "");
     setPreco("0");
     setQuantidadeMinimaDeCompra("1");
     await loadProdutos();
@@ -375,6 +391,25 @@ export default function Produtos() {
             </select>
           </div>
 
+          <div className="flex flex-col gap-2">
+            <label htmlFor="faixaEtaria" className="text-sm font-medium text-gray-700">Faixa etária</label>
+            <select
+              id="faixaEtaria"
+              value={faixaEtariaId}
+              onChange={e => setFaixaEtariaId(e.target.value)}
+              className={baseInputClasses}
+              disabled={!faixasEtarias.length}
+            >
+              {faixasEtarias.length === 0 ? (
+                <option value="" disabled>Carregando...</option>
+              ) : (
+                faixasEtarias.map(opcao => (
+                  <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
+                ))
+              )}
+            </select>
+          </div>
+
           <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
             <label htmlFor="portes" className="text-sm font-medium text-gray-700">Porte</label>
             <Select
@@ -447,7 +482,7 @@ export default function Produtos() {
                       {p.codigo} • {p.sabores}
                     </div>
                     <div className="text-sm text-gray-600">
-                      {p.especieNome} • {portesLabel || "Sem porte definido"} • {p.tipoProdutoNome}
+                      {p.especieNome} • {p.faixaEtariaNome} • {portesLabel || "Sem porte definido"} • {p.tipoProdutoNome}
                     </div>
                     <div className="text-sm font-medium text-gray-700">
                       mín: {minimo} un. • R$ {p.preco.toFixed(2)}


### PR DESCRIPTION
## Summary
- add a Faixa Etária option entity with seeded values and relate it to produtos
- extend produto DTOs, repository and service logic to validate and expose the faixa etária data and option list
- expose the faixa etária endpoint and update the admin/catalog front-end to manage and display the selected faixa etária

## Testing
- npm run build
- dotnet build backend/src/PremieRpet.Shop.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d342d06a94832dbea361cc3ab7ef09