### PR TITLE
Add reusable weight formatter

### DIFF
--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -10,6 +10,7 @@ import Login from "../views/Login";
 import Protected from "../auth/Protected";
 import { useUser } from "../auth/useUser";
 import { useCart } from "../cart/CartContext";
+import { formatPeso } from "../lib/format";
 
 export default function App() {
   const { instance } = useMsal();
@@ -18,6 +19,7 @@ export default function App() {
   const { account, isAdmin, isLoading, clearRolesCache } = useUser();
   const { totalUnidades, totalPesoKg, totalValor } = useCart();
   const isLoginRoute = location.pathname.startsWith("/login");
+  const pesoResumo = formatPeso(totalPesoKg, "kg", { unit: "kg", minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
   const gotoLogin = () => navigate("/login");
   const logout = async () => {
@@ -44,14 +46,14 @@ export default function App() {
               <button
                 onClick={() => navigate("/carrinho")}
                 className="relative flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-gray-50"
-                title={`Itens: ${totalUnidades} • ${totalPesoKg.toFixed(2)} kg • R$ ${totalValor.toFixed(2)}`}
+                title={`Itens: ${totalUnidades} • ${pesoResumo} • R$ ${totalValor.toFixed(2)}`}
               >
                 <ShoppingCart size={20} />
                 {/* contador */}
                 <span className="text-sm tabular-nums">{totalUnidades}</span>
                 {/* totals compactos */}
                 <span className="hidden md:inline text-xs text-gray-600">
-                  {totalPesoKg.toFixed(2)} kg • R$ {totalValor.toFixed(2)}
+                  {pesoResumo} • R$ {totalValor.toFixed(2)}
                 </span>
               </button>
 

--- a/frontend/src/views/Carrinho.tsx
+++ b/frontend/src/views/Carrinho.tsx
@@ -1,12 +1,15 @@
 import { useCart } from "../cart/CartContext";
 import { useNavigate } from "react-router-dom";
 import { ENV } from "../config/env";
-import { isBelowMin, itemSubtotal, itemPesoKg } from "../cart/calc";
+import { isBelowMin, itemSubtotal } from "../cart/calc";
+import { formatPeso } from "../lib/format";
 
 export default function Carrinho() {
   const { items, totalUnidades, totalValor, totalPesoKg, setQuantity, remove, clear, anyBelowMinimum } = useCart();
   const navigate = useNavigate();
   const passouLimite = totalPesoKg > ENV.LIMIT_KG_MES;
+  const totalPesoFormatado = formatPeso(totalPesoKg, "kg", { unit: "kg" });
+  const limiteMensalFormatado = formatPeso(ENV.LIMIT_KG_MES, "kg");
 
   if (!items.length) {
     return (
@@ -50,7 +53,7 @@ export default function Carrinho() {
                     </div>
                   </td>
                   <td className="py-2 pr-4">{i.preco.toFixed(2)}</td>
-                  <td className="py-2 pr-4">{i.pesoKg.toFixed(3)}</td>
+                  <td className="py-2 pr-4">{formatPeso(i.pesoKg, "kg", { unit: "kg", unitSuffix: false })}</td>
                   <td className="py-2 pr-4">
                     <input
                       type="number"
@@ -75,7 +78,7 @@ export default function Carrinho() {
             <tr className="border-t font-semibold">
               <td className="py-2">Totais</td>
               <td />
-              <td className="py-2">{totalPesoKg.toFixed(3)} kg</td>
+              <td className="py-2">{totalPesoFormatado}</td>
               <td className="py-2">{totalUnidades}</td>
               <td className="py-2">R$ {totalValor.toFixed(2)}</td>
               <td />
@@ -99,7 +102,7 @@ export default function Carrinho() {
 
       {passouLimite && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-          Atenção: seu carrinho tem {totalPesoKg.toFixed(3)} kg. O limite mensal é {ENV.LIMIT_KG_MES} kg por colaborador (validado no checkout).
+          Atenção: seu carrinho tem {totalPesoFormatado}. O limite mensal é {limiteMensalFormatado} por colaborador (validado no checkout).
         </div>
       )}
     </div>

--- a/frontend/src/views/Catalogo.tsx
+++ b/frontend/src/views/Catalogo.tsx
@@ -1,45 +1,176 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { CheckCircle2, ShoppingCart } from "lucide-react";
 import api from "../lib/api";
 import { useCart } from "../cart/CartContext";
 import type { Produto } from "../cart/types";
-import { ENV } from "../config/env";
 import { minQtyFor } from "../cart/calc";
+import { formatCurrencyBRL, formatPeso } from "../lib/format";
+
+const gradientClasses = [
+  "from-indigo-200 via-indigo-100 to-white",
+  "from-rose-200 via-rose-100 to-white",
+  "from-emerald-200 via-emerald-100 to-white",
+  "from-sky-200 via-sky-100 to-white",
+  "from-amber-200 via-amber-100 to-white",
+  "from-purple-200 via-purple-100 to-white",
+];
+
+type AddToCartFeedback = {
+  descricao: string;
+  quantidade: number;
+  subtotal: number;
+};
 
 export default function Catalogo() {
   const [produtos, setProdutos] = useState<Produto[]>([]);
   const { addProduct } = useCart();
+  const [feedback, setFeedback] = useState<AddToCartFeedback | null>(null);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const removeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     api.get("/catalogo").then(r => setProdutos(r.data));
   }, []);
 
-  return (
-    <div className="grid md:grid-cols-3 gap-4">
-      {produtos.map(p => {
-        const minimo = Math.max(ENV.QTD_MINIMA_PADRAO, p.quantidadeMinimaDeCompra || 0);
-        return (
-          <div key={p.codigo} className="bg-white p-4 rounded-xl shadow">
-            <div className="flex items-start justify-between gap-2">
-              <h3 className="font-semibold pr-2">{p.descricao}</h3>
-              {minimo > 1 && (
-                <span className="text-xs px-2 py-1 rounded-full bg-gray-100 border shrink-0">
-                  mín: {minimo} un.
-                </span>
-              )}
-            </div>
-            <p className="text-sm text-gray-500 mt-1">{p.sabores}</p>
-            <p className="text-xs text-indigo-600 mt-1 font-medium">Faixa etária: {p.faixaEtariaNome}</p>
-            <p className="mt-2">R$ {p.preco.toFixed(2)}</p>
+  useEffect(() => {
+    return () => {
+      if (hideTimeout.current) window.clearTimeout(hideTimeout.current);
+      if (removeTimeout.current) window.clearTimeout(removeTimeout.current);
+    };
+  }, []);
 
-            <button
-              className="mt-3 px-3 py-1 border rounded-lg"
-              onClick={() => addProduct(p, minQtyFor(p))} // começa direto no mínimo
-            >
-              Adicionar
-            </button>
+  const handleAdd = (produto: Produto) => {
+    const quantidade = minQtyFor(produto);
+    addProduct(produto, quantidade);
+
+    setFeedback({
+      descricao: produto.descricao,
+      quantidade,
+      subtotal: produto.preco * quantidade,
+    });
+    setShowFeedback(true);
+
+    if (hideTimeout.current) window.clearTimeout(hideTimeout.current);
+    if (removeTimeout.current) window.clearTimeout(removeTimeout.current);
+
+    hideTimeout.current = window.setTimeout(() => {
+      setShowFeedback(false);
+      removeTimeout.current = window.setTimeout(() => setFeedback(null), 300);
+    }, 2400);
+  };
+
+  return (
+    <div className="space-y-12">
+      <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center sm:top-8">
+        {feedback && (
+          <div
+            className={`flex max-w-sm items-start gap-3 rounded-2xl bg-white/90 px-4 py-3 text-left shadow-2xl ring-1 ring-indigo-100 backdrop-blur transition-all duration-300 ${showFeedback ? "translate-y-0 opacity-100" : "-translate-y-4 opacity-0"}`}
+            aria-live="polite"
+            role="status"
+          >
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-600/90 text-white shadow-inner">
+              <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-slate-900">
+                Adicionamos <span className="font-semibold">{feedback.quantidade}x</span> {feedback.descricao}
+              </p>
+              <p className="text-xs text-slate-600">
+                Subtotal adicionado de {formatCurrencyBRL(feedback.subtotal)} ao carrinho
+              </p>
+            </div>
           </div>
-        );
-      })}
+        )}
+      </div>
+
+      <section className="overflow-hidden rounded-3xl border border-indigo-100 bg-white px-8 py-12 text-center shadow-sm">
+        <span className="inline-flex items-center justify-center rounded-full bg-indigo-50 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-600">
+          Catálogo de produtos
+        </span>
+        <h1 className="mt-6 text-3xl font-bold text-slate-900 sm:text-4xl">Descubra a linha completa da nossa loja</h1>
+        <p className="mt-3 max-w-2xl mx-auto text-sm text-slate-600 sm:text-base">
+          Visualize todos os detalhes de cada item antes de adicionar ao carrinho: indicações, sabores, peso e faixa etária em um só lugar.
+        </p>
+      </section>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {produtos.map((p, index) => {
+          const minimo = minQtyFor(p);
+          const gradient = gradientClasses[index % gradientClasses.length];
+          const precoFormatado = formatCurrencyBRL(p.preco);
+          const portes = p.porteNomes.length ? p.porteNomes.join(", ") : "Todos os portes";
+
+          return (
+            <article
+              key={p.codigo}
+              className="group flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
+            >
+              <div className={`relative overflow-hidden bg-gradient-to-br ${gradient} px-5 py-6`}>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="inline-flex items-center rounded-full bg-white/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-700">
+                    {p.tipoProdutoNome}
+                  </span>
+                  {minimo > 1 && (
+                    <span className="rounded-full bg-slate-900/10 px-2.5 py-1 text-[10px] font-semibold text-slate-700">
+                      Mínimo {minimo} un.
+                    </span>
+                  )}
+                </div>
+                <h3 className="mt-4 text-lg font-semibold text-slate-900">{p.descricao}</h3>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-700">
+                  <span className="font-medium uppercase tracking-wide text-slate-600">Sabor:</span>
+                  <span>{p.sabores || "variedades"}</span>
+                  <span className="inline-flex items-center rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700">
+                    {p.especieNome}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex flex-1 flex-col gap-4 p-5">
+                <span className="text-[11px] font-mono uppercase tracking-wide text-slate-400">SKU #{p.codigo}</span>
+
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-[13px] text-slate-600">
+                  <div className="space-y-0.5">
+                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Peso</dt>
+                    <dd className="text-sm text-slate-900">{formatPeso(p.peso, p.tipoPeso)}</dd>
+                  </div>
+                  <div className="space-y-0.5">
+                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Faixa etária</dt>
+                    <dd className="text-sm text-slate-900">{p.faixaEtariaNome}</dd>
+                  </div>
+                  <div className="space-y-0.5">
+                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Sabores</dt>
+                    <dd className="text-sm text-slate-900">{p.sabores || "Não informado"}</dd>
+                  </div>
+                  <div className="space-y-0.5">
+                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Porte indicado</dt>
+                    <dd className="text-sm text-slate-900">{portes}</dd>
+                  </div>
+                  <div className="col-span-2 space-y-0.5">
+                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Categoria</dt>
+                    <dd className="text-sm text-slate-900">{p.tipoProdutoNome}</dd>
+                  </div>
+                </dl>
+
+                <div className="mt-auto flex items-center justify-between gap-3">
+                  <div>
+                    <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Preço</span>
+                    <p className="text-xl font-semibold text-slate-900">{precoFormatado}</p>
+                  </div>
+                  <button
+                    className="inline-flex items-center gap-1.5 rounded-full bg-indigo-600 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition-colors duration-200 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    onClick={() => handleAdd(p)}
+                  >
+                    <ShoppingCart className="h-3.5 w-3.5" aria-hidden="true" />
+                    Adicionar
+                  </button>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/views/Checkout.tsx
+++ b/frontend/src/views/Checkout.tsx
@@ -4,11 +4,14 @@ import { useCart } from "../cart/CartContext";
 import { useNavigate } from "react-router-dom";
 import { ENV } from "../config/env";
 import { useToast } from "../ui/toast";
+import { formatPeso } from "../lib/format";
 
 type UnidadeEntrega = string;
 
 export default function Checkout() {
   const { items, totalValor, totalPesoKg, clear, anyBelowMinimum } = useCart();
+  const pesoTotalFormatado = formatPeso(totalPesoKg, "kg", { unit: "kg" });
+  const limiteMensalFormatado = formatPeso(ENV.LIMIT_KG_MES, "kg");
   const [unidades, setUnidades] = useState<UnidadeEntrega[]>([]);
   const [unidade, setUnidade] = useState<string>("");
   const [loading, setLoading] = useState(false);
@@ -90,11 +93,11 @@ export default function Checkout() {
         <h2 className="font-semibold mb-3">Resumo</h2>
         <div className="grid grid-cols-2 gap-3 max-w-md">
           <div className="text-gray-600">Peso total</div>
-          <div>{totalPesoKg.toFixed(3)} kg</div>
+          <div>{pesoTotalFormatado}</div>
           <div className="text-gray-600">Valor total</div>
           <div>R$ {totalValor.toFixed(2)}</div>
           <div className="text-gray-600">Limite mensal</div>
-          <div>{ENV.LIMIT_KG_MES} kg</div>
+          <div>{limiteMensalFormatado}</div>
         </div>
 
         {anyBelowMinimum && (
@@ -105,7 +108,7 @@ export default function Checkout() {
 
         {totalPesoKg > ENV.LIMIT_KG_MES && (
           <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-            Atenção: seu carrinho tem {totalPesoKg.toFixed(3)} kg. O limite mensal é {ENV.LIMIT_KG_MES} kg (validado no backend).
+            Atenção: seu carrinho tem {pesoTotalFormatado}. O limite mensal é {limiteMensalFormatado} (validado no backend).
           </div>
         )}
 

--- a/frontend/src/views/Relatorios.tsx
+++ b/frontend/src/views/Relatorios.tsx
@@ -4,6 +4,7 @@ import type { PedidoDetalhe, Item } from "../report/types";
 import {
   formatCurrencyBRL,
   formatDateBR,
+  formatPeso,
   startOfDayISO_BR,
   endOfDayISO_BR,
 } from "../lib/format";
@@ -109,10 +110,10 @@ export default function Relatorios() {
               String(it.quantidade),
               String(it.preco).replace(".", ","),
               String(it.subtotal).replace(".", ","),
-              String(it.pesoKg).replace(".", ","),
-              String(it.pesoTotalKg).replace(".", ","),
+              formatPeso(it.pesoKg, "kg", { unit: "kg", unitSuffix: false, useGrouping: false }),
+              formatPeso(it.pesoTotalKg, "kg", { unit: "kg", unitSuffix: false, useGrouping: false }),
               String(p.total).replace(".", ","),
-              String(p.pesoTotalKg).replace(".", ","),
+              formatPeso(p.pesoTotalKg, "kg", { unit: "kg", unitSuffix: false, useGrouping: false }),
             ]
               .map((v) => `"${String(v).replaceAll('"', '""')}"`)
               .join(",")
@@ -206,7 +207,7 @@ export default function Relatorios() {
                   Total: <strong>{formatCurrencyBRL(g.totalValor)}</strong>
                 </span>
                 <span>
-                  Peso: <strong>{g.totalPeso.toFixed(3)} kg</strong>
+                  Peso: <strong>{formatPeso(g.totalPeso, "kg", { unit: "kg" })}</strong>
                 </span>
               </div>
             </div>
@@ -232,7 +233,7 @@ export default function Relatorios() {
                         <td className="px-4 py-2">{p.unidadeEntrega}</td>
                         <td className="px-4 py-2">{p.itens.length}</td>
                         <td className="px-4 py-2">{formatCurrencyBRL(p.total)}</td>
-                        <td className="px-4 py-2">{p.pesoTotalKg.toFixed(3)}</td>
+                        <td className="px-4 py-2">{formatPeso(p.pesoTotalKg, "kg", { unit: "kg", unitSuffix: false })}</td>
                         <td className="px-4 py-2 text-right">
                           <button
                             className="px-3 py-1 border rounded-lg text-sm hover:bg-gray-50"
@@ -269,8 +270,8 @@ export default function Relatorios() {
                                       <td className="px-3 py-2">{it.quantidade}</td>
                                       <td className="px-3 py-2">{formatCurrencyBRL(it.preco)}</td>
                                       <td className="px-3 py-2">{formatCurrencyBRL(it.subtotal)}</td>
-                                      <td className="px-3 py-2">{it.pesoKg.toFixed(3)}</td>
-                                      <td className="px-3 py-2">{it.pesoTotalKg.toFixed(3)}</td>
+                                      <td className="px-3 py-2">{formatPeso(it.pesoKg, "kg", { unit: "kg", unitSuffix: false })}</td>
+                                      <td className="px-3 py-2">{formatPeso(it.pesoTotalKg, "kg", { unit: "kg", unitSuffix: false })}</td>
                                     </tr>
                                   ))}
                                 </tbody>


### PR DESCRIPTION
## Summary
- add a shared `formatPeso` helper in `lib/format` that covers automatic unit conversion, precision, and optional suffix/grouping
- switch the catalog, shell cart summary, cart table, checkout, and reports (UI + CSV) to reuse the helper instead of manual weight strings

## Testing
- npm --prefix frontend run build *(fails: Rollup could not resolve the existing `react-select` import in `src/views/Produtos.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68d348382d30832db6402b1d7537c90c