### PR TITLE
Hide product form until add or edit is requested

### DIFF
--- a/frontend/src/views/Produtos.tsx
+++ b/frontend/src/views/Produtos.tsx
@@ -127,6 +127,12 @@ const saveButtonClasses = classNames(
   "focus:outline-none focus:ring-4 focus:ring-indigo-200 focus:ring-offset-1 focus:ring-offset-white",
 );
 
+const cancelButtonClasses = classNames(
+  "inline-flex items-center justify-center rounded-xl border border-gray-300 px-5 py-3 text-sm font-semibold text-gray-600",
+  "bg-white transition hover:bg-gray-100",
+  "focus:outline-none focus:ring-4 focus:ring-gray-200 focus:ring-offset-1 focus:ring-offset-white",
+);
+
 const productCardClasses = classNames(
   "flex flex-col gap-4 rounded-xl border border-gray-200 bg-white/80 p-4 shadow-sm transition",
   "hover:border-indigo-200 hover:shadow",
@@ -144,6 +150,12 @@ const deleteButtonClasses = classNames(
   "inline-flex items-center justify-center rounded-lg border border-transparent",
   "bg-red-50 px-3 py-1.5 text-xs font-semibold",
   "text-red-600 transition hover:bg-red-100 focus:outline-none focus:ring-4 focus:ring-red-100",
+);
+
+const editButtonClasses = classNames(
+  "inline-flex items-center justify-center rounded-lg border border-transparent",
+  "bg-indigo-50 px-3 py-1.5 text-xs font-semibold",
+  "text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus:ring-4 focus:ring-indigo-100",
 );
 
 const emptyStateClasses = classNames(
@@ -195,6 +207,10 @@ export default function Produtos() {
   const [preco, setPreco] = useState("0");
   const [quantidadeMinimaDeCompra, setQuantidadeMinimaDeCompra] = useState("1");
   const [opcoesCarregando, setOpcoesCarregando] = useState(true);
+  const [produtoEmEdicao, setProdutoEmEdicao] = useState<Produto | null>(null);
+  const [formAberto, setFormAberto] = useState(false);
+
+  const editando = produtoEmEdicao !== null;
 
   const pesoFormatter = useMemo(
     () =>
@@ -245,6 +261,50 @@ export default function Produtos() {
   };
 
   const loadProdutos = async () => setProdutos((await api.get("/produtos")).data);
+  const resetFormCampos = () => {
+    setProdutoEmEdicao(null);
+    setCodigo("");
+    setDescricao("");
+    setPeso("1");
+    setTipoPeso(1);
+    setSabores("");
+    setEspecieId(especies[0]?.id ?? "");
+    setPorteIds([]);
+    setTipoProdutoId(tiposProduto[0]?.id ?? "");
+    setFaixaEtariaId(faixasEtarias[0]?.id ?? "");
+    setPreco("0");
+    setQuantidadeMinimaDeCompra("1");
+  };
+
+  const fecharFormulario = () => {
+    resetFormCampos();
+    setFormAberto(false);
+  };
+
+  const iniciarNovoProduto = () => {
+    resetFormCampos();
+    setFormAberto(true);
+  };
+
+  const iniciarEdicao = (produto: Produto) => {
+    setFormAberto(true);
+    setProdutoEmEdicao(produto);
+    setCodigo(produto.codigo);
+    setDescricao(produto.descricao);
+    setPeso(pesoFormatter.format(produto.peso));
+    setTipoPeso(produto.tipoPeso);
+    setSabores(produto.sabores);
+    setEspecieId(produto.especieOpcaoId);
+    setPorteIds(produto.porteOpcaoIds);
+    setTipoProdutoId(produto.tipoProdutoOpcaoId);
+    setFaixaEtariaId(produto.faixaEtariaOpcaoId);
+    setPreco(produto.preco.toFixed(2).replace(".", ","));
+    setQuantidadeMinimaDeCompra(produto.quantidadeMinimaDeCompra.toString());
+  };
+
+  const cancelarFormulario = () => {
+    fecharFormulario();
+  };
   const loadOpcoes = async () => {
     try {
       setOpcoesCarregando(true);
@@ -316,6 +376,9 @@ export default function Produtos() {
     const faixaSelecionada = faixaEtariaId || faixasEtarias[0]?.id || "";
     if (!especieSelecionada || !tipoSelecionado || !faixaSelecionada) return;
 
+    const codigoParaSalvar = editando ? produtoEmEdicao!.codigo : codigo.trim();
+    if (!codigoParaSalvar) return;
+
     const dto = {
       descricao,
       peso: parseDecimalInput(peso),
@@ -328,222 +391,235 @@ export default function Produtos() {
       preco: parseDecimalInput(preco),
       quantidadeMinimaDeCompra: Math.max(1, parseIntegerInput(quantidadeMinimaDeCompra)),
     };
-    await api.post(`/produtos/${codigo}`, dto);
-    setCodigo("");
-    setDescricao("");
-    setPeso("1");
-    setTipoPeso(1);
-    setSabores("");
-    setEspecieId(especies[0]?.id ?? "");
-    setPorteIds([]);
-    setTipoProdutoId(tiposProduto[0]?.id ?? "");
-    setFaixaEtariaId(faixasEtarias[0]?.id ?? "");
-    setPreco("0");
-    setQuantidadeMinimaDeCompra("1");
+    if (editando) {
+      await api.put(`/produtos/${codigoParaSalvar}`, dto);
+    } else {
+      await api.post(`/produtos/${codigoParaSalvar}`, dto);
+    }
     await loadProdutos();
+    fecharFormulario();
   };
 
   const remover = async (c: string) => {
     await api.delete(`/produtos/${c}`);
     await loadProdutos();
+    if (produtoEmEdicao?.codigo === c) {
+      fecharFormulario();
+    }
   };
 
   return (
     <div className="space-y-8">
-      <div className="rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm backdrop-blur">
-        <div className="mb-6 space-y-2">
-          <h2 className="text-xl font-semibold text-gray-900">Novo produto</h2>
-          <p className="text-sm text-gray-500">
-            Preencha os campos abaixo para cadastrar um novo item em seu catálogo.
-          </p>
+      {formAberto && (
+        <div className="rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm backdrop-blur">
+          <div className="mb-6 space-y-2">
+            <h2 className="text-xl font-semibold text-gray-900">
+              {editando ? "Editar produto" : "Novo produto"}
+            </h2>
+            <p className="text-sm text-gray-500">
+              {editando
+                ? `Atualize os dados do produto ${produtoEmEdicao?.codigo} e salve as alterações.`
+                : "Preencha os campos abaixo para cadastrar um novo item em seu catálogo."}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="codigo" className="text-sm font-medium text-gray-700">Código</label>
+              <input
+                id="codigo"
+                placeholder="Ex: R128"
+                value={codigo}
+                onChange={e => setCodigo(e.target.value)}
+                className={baseInputClasses}
+                disabled={editando}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
+              <label htmlFor="descricao" className="text-sm font-medium text-gray-700">Descrição</label>
+              <input
+                id="descricao"
+                placeholder="Nome do produto"
+                value={descricao}
+                onChange={e => setDescricao(e.target.value)}
+                className={baseInputClasses}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="peso" className="text-sm font-medium text-gray-700">Peso</label>
+              <input
+                id="peso"
+                type="text"
+                inputMode="decimal"
+                placeholder="0,00"
+                value={peso}
+                onChange={e => setPeso(sanitizeDecimalInput(e.target.value))}
+                className={baseInputClasses}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="tipoPeso" className="text-sm font-medium text-gray-700">Tipo de peso</label>
+              <select
+                id="tipoPeso"
+                value={tipoPeso}
+                onChange={e => setTipoPeso(parseInt(e.target.value, 10))}
+                className={baseInputClasses}
+              >
+                <option value={0}>Grama</option>
+                <option value={1}>Quilo</option>
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="qtdMin" className="text-sm font-medium text-gray-700">Qtd mínima (unidades)</label>
+              <input
+                id="qtdMin"
+                type="text"
+                inputMode="numeric"
+                placeholder="1"
+                value={quantidadeMinimaDeCompra}
+                onChange={e => setQuantidadeMinimaDeCompra(e.target.value.replace(/[^0-9]/g, ""))}
+                className={baseInputClasses}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
+              <label htmlFor="sabores" className="text-sm font-medium text-gray-700">Sabores</label>
+              <input
+                id="sabores"
+                placeholder="Informe os sabores separados por vírgula"
+                value={sabores}
+                onChange={e => setSabores(e.target.value)}
+                className={baseInputClasses}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="especie" className="text-sm font-medium text-gray-700">Espécie</label>
+              <select
+                id="especie"
+                value={especieId}
+                onChange={e => setEspecieId(e.target.value)}
+                className={baseInputClasses}
+                disabled={!especies.length}
+              >
+                {especies.length === 0 ? (
+                  <option value="" disabled>Carregando...</option>
+                ) : (
+                  especies.map(opcao => (
+                    <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
+                  ))
+                )}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
+              <label htmlFor="tipoProduto" className="text-sm font-medium text-gray-700">Tipo do Produto</label>
+              <select
+                id="tipoProduto"
+                value={tipoProdutoId}
+                onChange={e => setTipoProdutoId(e.target.value)}
+                className={baseInputClasses}
+                disabled={!tiposProduto.length}
+              >
+                {tiposProduto.length === 0 ? (
+                  <option value="" disabled>Carregando...</option>
+                ) : (
+                  tiposProduto.map(opcao => (
+                    <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
+                  ))
+                )}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="faixaEtaria" className="text-sm font-medium text-gray-700">Faixa etária</label>
+              <select
+                id="faixaEtaria"
+                value={faixaEtariaId}
+                onChange={e => setFaixaEtariaId(e.target.value)}
+                className={baseInputClasses}
+                disabled={!faixasEtarias.length}
+              >
+                {faixasEtarias.length === 0 ? (
+                  <option value="" disabled>Carregando...</option>
+                ) : (
+                  faixasEtarias.map(opcao => (
+                    <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
+                  ))
+                )}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
+              <label htmlFor="portes" className="text-sm font-medium text-gray-700">Porte</label>
+              <Select
+                inputId="portes"
+                isMulti
+                isDisabled={opcoesCarregando || !porteSelectOptions.length}
+                isLoading={opcoesCarregando}
+                menuPortalTarget={document.body}
+                menuPosition="fixed"
+                value={selectedPorteOptions}
+                onChange={handlePorteChange}
+                options={porteSelectOptions}
+                placeholder={opcoesCarregando ? "Carregando..." : "Selecione os portes"}
+                closeMenuOnSelect={false}
+                noOptionsMessage={() => (opcoesCarregando ? "Carregando..." : "Nenhuma opção disponível")}
+                className="text-sm"
+                styles={porteSelectStyles}
+              />
+              <span className="text-xs text-gray-500">Escolha um ou mais portes que melhor representam o produto.</span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="preco" className="text-sm font-medium text-gray-700">Preço (R$)</label>
+              <input
+                id="preco"
+                type="text"
+                inputMode="decimal"
+                placeholder="0,00"
+                value={preco}
+                onChange={e => setPreco(sanitizeDecimalInput(e.target.value))}
+                className={baseInputClasses}
+              />
+            </div>
+
+            <div className="flex justify-end gap-3 md:col-span-2 xl:col-span-3">
+              <button onClick={cancelarFormulario} className={cancelButtonClasses}>
+                {editando ? "Cancelar edição" : "Cancelar"}
+              </button>
+              <button
+                onClick={salvar}
+                className={saveButtonClasses}
+                disabled={!editando && !codigo.trim()}
+              >
+                {editando ? "Salvar alterações" : "Salvar produto"}
+              </button>
+            </div>
+          </div>
         </div>
-
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
-          <div className="flex flex-col gap-2">
-            <label htmlFor="codigo" className="text-sm font-medium text-gray-700">Código</label>
-            <input
-              id="codigo"
-              placeholder="Ex: R128"
-              value={codigo}
-              onChange={e => setCodigo(e.target.value)}
-              className={baseInputClasses}
-            />
-          </div>
-
-          <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
-            <label htmlFor="descricao" className="text-sm font-medium text-gray-700">Descrição</label>
-            <input
-              id="descricao"
-              placeholder="Nome do produto"
-              value={descricao}
-              onChange={e => setDescricao(e.target.value)}
-              className={baseInputClasses}
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label htmlFor="peso" className="text-sm font-medium text-gray-700">Peso</label>
-            <input
-              id="peso"
-              type="text"
-              inputMode="decimal"
-              placeholder="0,00"
-              value={peso}
-              onChange={e => setPeso(sanitizeDecimalInput(e.target.value))}
-              className={baseInputClasses}
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label htmlFor="tipoPeso" className="text-sm font-medium text-gray-700">Tipo de peso</label>
-            <select
-              id="tipoPeso"
-              value={tipoPeso}
-              onChange={e => setTipoPeso(parseInt(e.target.value, 10))}
-              className={baseInputClasses}
-            >
-              <option value={0}>Grama</option>
-              <option value={1}>Quilo</option>
-            </select>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label htmlFor="qtdMin" className="text-sm font-medium text-gray-700">Qtd mínima (unidades)</label>
-            <input
-              id="qtdMin"
-              type="text"
-              inputMode="numeric"
-              placeholder="1"
-              value={quantidadeMinimaDeCompra}
-              onChange={e => setQuantidadeMinimaDeCompra(e.target.value.replace(/[^0-9]/g, ""))}
-              className={baseInputClasses}
-            />
-          </div>
-
-          <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
-            <label htmlFor="sabores" className="text-sm font-medium text-gray-700">Sabores</label>
-            <input
-              id="sabores"
-              placeholder="Informe os sabores separados por vírgula"
-              value={sabores}
-              onChange={e => setSabores(e.target.value)}
-              className={baseInputClasses}
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label htmlFor="especie" className="text-sm font-medium text-gray-700">Espécie</label>
-            <select
-              id="especie"
-              value={especieId}
-              onChange={e => setEspecieId(e.target.value)}
-              className={baseInputClasses}
-              disabled={!especies.length}
-            >
-              {especies.length === 0 ? (
-                <option value="" disabled>Carregando...</option>
-              ) : (
-                especies.map(opcao => (
-                  <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
-                ))
-              )}
-            </select>
-          </div>
-
-          <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
-            <label htmlFor="tipoProduto" className="text-sm font-medium text-gray-700">Tipo do Produto</label>
-            <select
-              id="tipoProduto"
-              value={tipoProdutoId}
-              onChange={e => setTipoProdutoId(e.target.value)}
-              className={baseInputClasses}
-              disabled={!tiposProduto.length}
-            >
-              {tiposProduto.length === 0 ? (
-                <option value="" disabled>Carregando...</option>
-              ) : (
-                tiposProduto.map(opcao => (
-                  <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
-                ))
-              )}
-            </select>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label htmlFor="faixaEtaria" className="text-sm font-medium text-gray-700">Faixa etária</label>
-            <select
-              id="faixaEtaria"
-              value={faixaEtariaId}
-              onChange={e => setFaixaEtariaId(e.target.value)}
-              className={baseInputClasses}
-              disabled={!faixasEtarias.length}
-            >
-              {faixasEtarias.length === 0 ? (
-                <option value="" disabled>Carregando...</option>
-              ) : (
-                faixasEtarias.map(opcao => (
-                  <option key={opcao.id} value={opcao.id}>{opcao.nome}</option>
-                ))
-              )}
-            </select>
-          </div>
-
-          <div className="flex flex-col gap-2 md:col-span-2 xl:col-span-2">
-            <label htmlFor="portes" className="text-sm font-medium text-gray-700">Porte</label>
-            <Select
-              inputId="portes"
-              isMulti
-              isDisabled={opcoesCarregando || !porteSelectOptions.length}
-              isLoading={opcoesCarregando}
-              menuPortalTarget={document.body}
-              menuPosition="fixed"
-              value={selectedPorteOptions}
-              onChange={handlePorteChange}
-              options={porteSelectOptions}
-              placeholder={opcoesCarregando ? "Carregando..." : "Selecione os portes"}
-              closeMenuOnSelect={false}
-              noOptionsMessage={() => (opcoesCarregando ? "Carregando..." : "Nenhuma opção disponível")}
-              className="text-sm"
-              styles={porteSelectStyles}
-            />
-            <span className="text-xs text-gray-500">Escolha um ou mais portes que melhor representam o produto.</span>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label htmlFor="preco" className="text-sm font-medium text-gray-700">Preço (R$)</label>
-            <input
-              id="preco"
-              type="text"
-              inputMode="decimal"
-              placeholder="0,00"
-              value={preco}
-              onChange={e => setPreco(sanitizeDecimalInput(e.target.value))}
-              className={baseInputClasses}
-            />
-          </div>
-
-          <div className="flex justify-end md:col-span-2 xl:col-span-3">
-            <button
-              onClick={salvar}
-              className={saveButtonClasses}
-            >
-              Salvar produto
-            </button>
-          </div>
-        </div>
-      </div>
+      )}
 
       <div className="rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm backdrop-blur">
-        <div className="mb-4">
-          <h2 className="text-xl font-semibold text-gray-900">Produtos</h2>
-          <p className="text-sm text-gray-500">
-            Acompanhe os itens cadastrados e exclua aqueles que não fazem mais parte do catálogo.
-          </p>
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Produtos</h2>
+            <p className="text-sm text-gray-500">
+              Acompanhe os itens cadastrados e utilize o botão "Adicionar produto" para incluir novos produtos.
+            </p>
+          </div>
+          <button onClick={iniciarNovoProduto} className={saveButtonClasses}>
+            Adicionar produto
+          </button>
         </div>
         <div className="grid gap-3">
           {produtos.length === 0 ? (
             <div className={emptyStateClasses}>
-              Nenhum produto cadastrado por aqui ainda. Utilize o formulário acima para adicionar o primeiro item.
+              Nenhum produto cadastrado por aqui ainda. Clique em &quot;Adicionar produto&quot; para cadastrar o primeiro item.
             </div>
           ) : (
             produtos.map(p => {
@@ -586,6 +662,9 @@ export default function Produtos() {
                       </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-3 text-sm">
+                      <button onClick={() => iniciarEdicao(p)} className={editButtonClasses}>
+                        Editar
+                      </button>
                       <button onClick={() => remover(p.codigo)} className={deleteButtonClasses}>
                         Excluir
                       </button>


### PR DESCRIPTION
## Summary
- track whether the product form is open so it can be reset when closing or starting a new item
- render the product form only when adding or editing, with cancel controls that hide it again
- add an "Adicionar produto" button to the list header and update the empty state messaging accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3668fab64832d8dcd3fb85a0d4262