### PR TITLE
Fix produtos view for paginated API response

### DIFF
--- a/backend/src/PremieRpet.Shop.Api/Contracts/ProdutoFiltroQuery.cs
+++ b/backend/src/PremieRpet.Shop.Api/Contracts/ProdutoFiltroQuery.cs
@@ -1,0 +1,35 @@
+using System;
+using PremieRpet.Shop.Application.DTOs;
+
+namespace PremieRpet.Shop.Api.Contracts;
+
+public sealed class ProdutoFiltroQuery
+{
+    public string? Codigo { get; set; }
+    public string? Descricao { get; set; }
+    public string? Q { get; set; }
+    public Guid? TipoProdutoOpcaoId { get; set; }
+    public Guid? EspecieOpcaoId { get; set; }
+    public Guid? FaixaEtariaOpcaoId { get; set; }
+    public Guid? PorteOpcaoId { get; set; }
+    public int? Page { get; set; }
+
+    private static string? Normalize(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static Guid? Normalize(Guid? value)
+        => value is Guid guid && guid == Guid.Empty ? null : value;
+
+    private static int NormalizePage(int? value)
+        => value is int page && page > 0 ? page : 1;
+
+    public ProdutoFiltroDto ToDto() => new(
+        Normalize(Codigo),
+        Normalize(Descricao) ?? Normalize(Q),
+        Normalize(TipoProdutoOpcaoId),
+        Normalize(EspecieOpcaoId),
+        Normalize(FaixaEtariaOpcaoId),
+        Normalize(PorteOpcaoId),
+        NormalizePage(Page),
+        ProdutoFiltroDto.DefaultPageSize);
+}

--- a/backend/src/PremieRpet.Shop.Api/Controllers/CatalogoController.cs
+++ b/backend/src/PremieRpet.Shop.Api/Controllers/CatalogoController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PremieRpet.Shop.Api.Contracts;
 using PremieRpet.Shop.Application.DTOs;
 using PremieRpet.Shop.Application.Interfaces.UseCases;
 
@@ -11,6 +12,6 @@ public class CatalogoController(IProdutoService svc) : ControllerBase
 {
     [HttpGet]
     [Authorize]
-    public Task<IReadOnlyList<ProdutoDto>> List([FromQuery] string? q, CancellationToken ct)
-        => svc.ListAsync(q, ct);
+    public Task<PagedResultDto<ProdutoDto>> List([FromQuery] ProdutoFiltroQuery filtro, CancellationToken ct)
+        => svc.ListAsync(filtro?.ToDto(), ct);
 }

--- a/backend/src/PremieRpet.Shop.Api/Controllers/ProdutosController.cs
+++ b/backend/src/PremieRpet.Shop.Api/Controllers/ProdutosController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PremieRpet.Shop.Api.Contracts;
 using PremieRpet.Shop.Application.DTOs;
 using PremieRpet.Shop.Application.Interfaces.UseCases;
 
@@ -12,8 +13,8 @@ public class ProdutosController(IProdutoService svc) : ControllerBase
 {
     [HttpGet]
     [Authorize]
-    public async Task<ActionResult<IReadOnlyList<ProdutoDto>>> List([FromQuery] string? q, CancellationToken ct)
-        => Ok(await svc.ListAsync(q, ct));
+    public async Task<ActionResult<PagedResultDto<ProdutoDto>>> List([FromQuery] ProdutoFiltroQuery filtro, CancellationToken ct)
+        => Ok(await svc.ListAsync(filtro?.ToDto(), ct));
 
     [HttpGet("especies")]
     [Authorize]

--- a/backend/src/PremieRpet.Shop.Application/DTOs/PagedResultDto.cs
+++ b/backend/src/PremieRpet.Shop.Application/DTOs/PagedResultDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace PremieRpet.Shop.Application.DTOs;
+
+public sealed record PagedResultDto<T>(
+    IReadOnlyList<T> Items,
+    int Page,
+    int PageSize,
+    int TotalItems,
+    int TotalPages);

--- a/backend/src/PremieRpet.Shop.Application/DTOs/ProdutoFiltroDto.cs
+++ b/backend/src/PremieRpet.Shop.Application/DTOs/ProdutoFiltroDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PremieRpet.Shop.Application.DTOs;
+
+public sealed record ProdutoFiltroDto(
+    string? Codigo,
+    string? Descricao,
+    Guid? TipoProdutoOpcaoId,
+    Guid? EspecieOpcaoId,
+    Guid? FaixaEtariaOpcaoId,
+    Guid? PorteOpcaoId,
+    int Page,
+    int PageSize)
+{
+    public const int DefaultPageSize = 10;
+}

--- a/backend/src/PremieRpet.Shop.Application/Interfaces/UseCases/IProdutoService.cs
+++ b/backend/src/PremieRpet.Shop.Application/Interfaces/UseCases/IProdutoService.cs
@@ -6,7 +6,7 @@ namespace PremieRpet.Shop.Application.Interfaces.UseCases;
 public interface IProdutoService
 {
     Task<ProdutoDto?> GetByCodigoAsync(string codigo, CancellationToken ct);
-    Task<IReadOnlyList<ProdutoDto>> ListAsync(string? filtro, CancellationToken ct);
+    Task<PagedResultDto<ProdutoDto>> ListAsync(ProdutoFiltroDto? filtro, CancellationToken ct);
     Task CreateAsync(string codigo, ProdutoCreateUpdateDto dto, CancellationToken ct);
     Task UpdateAsync(string codigo, ProdutoCreateUpdateDto dto, CancellationToken ct);
     Task DeleteAsync(string codigo, CancellationToken ct);

--- a/frontend/src/views/Catalogo.tsx
+++ b/frontend/src/views/Catalogo.tsx
@@ -15,10 +15,30 @@ const gradientClasses = [
   "from-purple-200 via-purple-100 to-white",
 ];
 
+const DEFAULT_PAGE_SIZE = 10;
+
 type AddToCartFeedback = {
   descricao: string;
   quantidade: number;
   subtotal: number;
+};
+
+type ProdutoOpcao = {
+  id: string;
+  nome: string;
+};
+
+type SelectOption = {
+  value: string;
+  label: string;
+};
+
+type CatalogoResponse = {
+  items: Produto[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
 };
 
 export default function Catalogo() {
@@ -28,10 +48,134 @@ export default function Catalogo() {
   const [showFeedback, setShowFeedback] = useState(false);
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const removeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [codigoFiltro, setCodigoFiltro] = useState("");
+  const [descricaoFiltro, setDescricaoFiltro] = useState("");
+  const [tipoProdutoFiltro, setTipoProdutoFiltro] = useState("");
+  const [especieFiltro, setEspecieFiltro] = useState("");
+  const [faixaEtariaFiltro, setFaixaEtariaFiltro] = useState("");
+  const [porteFiltro, setPorteFiltro] = useState("");
+  const [tipoProdutoOptions, setTipoProdutoOptions] = useState<SelectOption[]>([]);
+  const [especieOptions, setEspecieOptions] = useState<SelectOption[]>([]);
+  const [faixaEtariaOptions, setFaixaEtariaOptions] = useState<SelectOption[]>([]);
+  const [porteOptions, setPorteOptions] = useState<SelectOption[]>([]);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const catalogoRequestIdRef = useRef(0);
+
+  const hasFilters = Boolean(
+    codigoFiltro.trim() ||
+      descricaoFiltro.trim() ||
+      tipoProdutoFiltro ||
+      especieFiltro ||
+      faixaEtariaFiltro ||
+      porteFiltro,
+  );
+
+  const clearFilters = () => {
+    setCodigoFiltro("");
+    setDescricaoFiltro("");
+    setTipoProdutoFiltro("");
+    setEspecieFiltro("");
+    setFaixaEtariaFiltro("");
+    setPorteFiltro("");
+    setPage(1);
+  };
 
   useEffect(() => {
-    api.get("/catalogo").then(r => setProdutos(r.data));
+    let isSubscribed = true;
+
+    const loadOptions = async () => {
+      try {
+        const [tiposResp, especiesResp, faixasResp, portesResp] = await Promise.all([
+          api.get<ProdutoOpcao[]>("/produtos/tipos-produto"),
+          api.get<ProdutoOpcao[]>("/produtos/especies"),
+          api.get<ProdutoOpcao[]>("/produtos/faixas-etarias"),
+          api.get<ProdutoOpcao[]>("/produtos/portes"),
+        ]);
+
+        if (!isSubscribed) return;
+
+        const mapToOption = (opcao: ProdutoOpcao): SelectOption => ({
+          value: opcao.id,
+          label: opcao.nome,
+        });
+
+        setTipoProdutoOptions(tiposResp.data.map(mapToOption));
+        setEspecieOptions(especiesResp.data.map(mapToOption));
+        setFaixaEtariaOptions(faixasResp.data.map(mapToOption));
+        setPorteOptions(portesResp.data.map(mapToOption));
+      } catch (error) {
+        if (!isSubscribed) return;
+        console.error("Não foi possível carregar as opções de filtro do catálogo", error);
+      }
+    };
+
+    loadOptions();
+
+    return () => {
+      isSubscribed = false;
+    };
   }, []);
+
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    const codigo = codigoFiltro.trim();
+    const descricao = descricaoFiltro.trim();
+
+    if (codigo) params.codigo = codigo;
+    if (descricao) params.descricao = descricao;
+    if (tipoProdutoFiltro) params.tipoProdutoOpcaoId = tipoProdutoFiltro;
+    if (especieFiltro) params.especieOpcaoId = especieFiltro;
+    if (faixaEtariaFiltro) params.faixaEtariaOpcaoId = faixaEtariaFiltro;
+    if (porteFiltro) params.porteOpcaoId = porteFiltro;
+    params.page = Math.max(page, 1).toString();
+
+    const requestId = ++catalogoRequestIdRef.current;
+    let isSubscribed = true;
+
+    api
+      .get<CatalogoResponse>("/catalogo", { params })
+      .then(response => {
+        if (!isSubscribed || catalogoRequestIdRef.current !== requestId) return;
+        const {
+          items,
+          page: currentPage,
+          pageSize: currentPageSize,
+          totalItems: currentTotal,
+          totalPages: currentTotalPages,
+        } = response.data;
+
+        const safePageSize = currentPageSize > 0 ? currentPageSize : DEFAULT_PAGE_SIZE;
+        const safePage = currentPage > 0 ? currentPage : 1;
+
+        setProdutos(items);
+        setPageSize(safePageSize);
+        setTotalItems(Math.max(0, currentTotal));
+        setTotalPages(Math.max(0, currentTotalPages));
+
+        if (safePage !== page) {
+          setPage(safePage);
+        }
+      })
+      .catch(error => {
+        if (!isSubscribed || catalogoRequestIdRef.current !== requestId) return;
+        console.error("Não foi possível carregar os produtos do catálogo", error);
+      });
+
+    return () => {
+      isSubscribed = false;
+    };
+  }, [
+    codigoFiltro,
+    descricaoFiltro,
+    tipoProdutoFiltro,
+    especieFiltro,
+    faixaEtariaFiltro,
+    porteFiltro,
+    page,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -59,6 +203,21 @@ export default function Catalogo() {
       removeTimeout.current = window.setTimeout(() => setFeedback(null), 5000);
     }, 5000);
   };
+
+  const hasProdutos = produtos.length > 0;
+  const safePageSize = pageSize > 0 ? pageSize : DEFAULT_PAGE_SIZE;
+  const safeTotalItems = hasProdutos ? Math.max(totalItems, produtos.length) : totalItems;
+  const normalizedTotalPages = safeTotalItems > 0
+    ? (totalPages > 0 ? totalPages : Math.max(Math.ceil(safeTotalItems / safePageSize), 1))
+    : 0;
+  const safePage = normalizedTotalPages > 0
+    ? Math.min(Math.max(page, 1), normalizedTotalPages)
+    : 1;
+  const showingStart = hasProdutos ? (safePage - 1) * safePageSize + 1 : 0;
+  const showingEnd = hasProdutos ? Math.min(showingStart + produtos.length - 1, safeTotalItems) : 0;
+  const canGoPrev = hasProdutos && safePage > 1;
+  const canGoNext = hasProdutos && normalizedTotalPages > 0 && safePage < normalizedTotalPages;
+  const displayTotalPages = normalizedTotalPages > 0 ? normalizedTotalPages : 1;
 
   return (
     <div className="space-y-12">
@@ -91,83 +250,289 @@ export default function Catalogo() {
         </p>
       </section>
 
-      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        {produtos.map((p, index) => {
-          const minimo = minQtyFor(p);
-          const gradient = gradientClasses[index % gradientClasses.length];
-          const precoFormatado = formatCurrencyBRL(p.preco);
-          const portes = p.porteNomes.length ? p.porteNomes.join(", ") : "Todos os portes";
+      <section className="rounded-3xl border border-indigo-100 bg-white/80 px-6 py-6 shadow-sm">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="text-left">
+              <h2 className="text-lg font-semibold text-slate-900">Filtrar produtos</h2>
+              <p className="text-sm text-slate-500">Refine o catálogo utilizando os campos abaixo.</p>
+            </div>
+            {hasFilters && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="inline-flex items-center gap-2 rounded-full border border-indigo-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2"
+              >
+                Limpar filtros
+              </button>
+            )}
+          </div>
 
-          return (
-            <article
-              key={p.codigo}
-              className="group flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
-            >
-              <div className={`relative overflow-hidden bg-gradient-to-br ${gradient} px-5 py-6`}>
-                <div className="flex items-center justify-between gap-3">
-                  <span className="inline-flex items-center rounded-full bg-white/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-700">
-                    {p.tipoProdutoNome}
-                  </span>
-                  {minimo > 1 && (
-                    <span className="rounded-full bg-slate-900/10 px-2.5 py-1 text-[10px] font-semibold text-slate-700">
-                      Mínimo {minimo} un.
-                    </span>
-                  )}
-                </div>
-                <h3 className="mt-4 text-lg font-semibold text-slate-900">{p.descricao}</h3>
-                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-700">
-                  <span className="font-medium uppercase tracking-wide text-slate-600">Sabor:</span>
-                  <span>{p.sabores || "variedades"}</span>
-                  <span className="inline-flex items-center rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700">
-                    {p.especieNome}
-                  </span>
-                </div>
-              </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="flex flex-col gap-2 text-left">
+              <label
+                htmlFor="catalogo-filtro-codigo"
+                className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                Código
+              </label>
+              <input
+                id="catalogo-filtro-codigo"
+                type="text"
+                value={codigoFiltro}
+                onChange={event => {
+                  setCodigoFiltro(event.target.value);
+                  setPage(1);
+                }}
+                placeholder="Buscar por código"
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              />
+            </div>
 
-              <div className="flex flex-1 flex-col gap-4 p-5">
-                <span className="text-[11px] font-mono uppercase tracking-wide text-slate-400">SKU #{p.codigo}</span>
+            <div className="flex flex-col gap-2 text-left">
+              <label
+                htmlFor="catalogo-filtro-descricao"
+                className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                Descrição
+              </label>
+              <input
+                id="catalogo-filtro-descricao"
+                type="text"
+                value={descricaoFiltro}
+                onChange={event => {
+                  setDescricaoFiltro(event.target.value);
+                  setPage(1);
+                }}
+                placeholder="Buscar por descrição"
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              />
+            </div>
 
-                <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-[13px] text-slate-600">
-                  <div className="space-y-0.5">
-                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Peso</dt>
-                    <dd className="text-sm text-slate-900">{formatPeso(p.peso, p.tipoPeso)}</dd>
-                  </div>
-                  <div className="space-y-0.5">
-                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Faixa etária</dt>
-                    <dd className="text-sm text-slate-900">{p.faixaEtariaNome}</dd>
-                  </div>
-                  <div className="space-y-0.5">
-                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Sabores</dt>
-                    <dd className="text-sm text-slate-900">{p.sabores || "Não informado"}</dd>
-                  </div>
-                  <div className="space-y-0.5">
-                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Porte indicado</dt>
-                    <dd className="text-sm text-slate-900">{portes}</dd>
-                  </div>
-                  <div className="col-span-2 space-y-0.5">
-                    <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Categoria</dt>
-                    <dd className="text-sm text-slate-900">{p.tipoProdutoNome}</dd>
-                  </div>
-                </dl>
+            <div className="flex flex-col gap-2 text-left">
+              <label
+                htmlFor="catalogo-filtro-tipo-produto"
+                className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                Tipo do produto
+              </label>
+              <select
+                id="catalogo-filtro-tipo-produto"
+                value={tipoProdutoFiltro}
+                onChange={event => {
+                  setTipoProdutoFiltro(event.target.value);
+                  setPage(1);
+                }}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              >
+                <option value="">Todos os tipos</option>
+                {tipoProdutoOptions.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
 
-                <div className="mt-auto flex items-center justify-between gap-3">
-                  <div>
-                    <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Preço</span>
-                    <p className="text-xl font-semibold text-slate-900">{precoFormatado}</p>
+            <div className="flex flex-col gap-2 text-left">
+              <label
+                htmlFor="catalogo-filtro-especie"
+                className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                Espécie
+              </label>
+              <select
+                id="catalogo-filtro-especie"
+                value={especieFiltro}
+                onChange={event => {
+                  setEspecieFiltro(event.target.value);
+                  setPage(1);
+                }}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              >
+                <option value="">Todas as espécies</option>
+                {especieOptions.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2 text-left">
+              <label
+                htmlFor="catalogo-filtro-faixa-etaria"
+                className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                Faixa etária
+              </label>
+              <select
+                id="catalogo-filtro-faixa-etaria"
+                value={faixaEtariaFiltro}
+                onChange={event => {
+                  setFaixaEtariaFiltro(event.target.value);
+                  setPage(1);
+                }}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              >
+                <option value="">Todas as faixas</option>
+                {faixaEtariaOptions.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2 text-left">
+              <label
+                htmlFor="catalogo-filtro-porte"
+                className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                Porte
+              </label>
+              <select
+                id="catalogo-filtro-porte"
+                value={porteFiltro}
+                onChange={event => {
+                  setPorteFiltro(event.target.value);
+                  setPage(1);
+                }}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              >
+                <option value="">Todos os portes</option>
+                {porteOptions.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {hasProdutos ? (
+        <div className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {produtos.map((p, index) => {
+              const minimo = minQtyFor(p);
+              const gradient = gradientClasses[index % gradientClasses.length];
+              const precoFormatado = formatCurrencyBRL(p.preco);
+              const portes = p.porteNomes.length ? p.porteNomes.join(", ") : "Todos os portes";
+
+              return (
+                <article
+                  key={p.codigo}
+                  className="group flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <div className={`relative overflow-hidden bg-gradient-to-br ${gradient} px-5 py-6`}>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="inline-flex items-center rounded-full bg-white/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-700">
+                        {p.tipoProdutoNome}
+                      </span>
+                      {minimo > 1 && (
+                        <span className="rounded-full bg-slate-900/10 px-2.5 py-1 text-[10px] font-semibold text-slate-700">
+                          Mínimo {minimo} un.
+                        </span>
+                      )}
+                    </div>
+                    <h3 className="mt-4 text-lg font-semibold text-slate-900">{p.descricao}</h3>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-700">
+                      <span className="font-medium uppercase tracking-wide text-slate-600">Sabor:</span>
+                      <span>{p.sabores || "variedades"}</span>
+                      <span className="inline-flex items-center rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700">
+                        {p.especieNome}
+                      </span>
+                    </div>
                   </div>
-                  <button
-                    className="inline-flex items-center gap-1.5 rounded-full bg-indigo-600 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition-colors duration-200 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-                    onClick={() => handleAdd(p)}
-                  >
-                    <ShoppingCart className="h-3.5 w-3.5" aria-hidden="true" />
-                    Adicionar
-                  </button>
-                </div>
-              </div>
-            </article>
-          );
-        })}
-      </div>
+
+                  <div className="flex flex-1 flex-col gap-4 p-5">
+                    <span className="text-[11px] font-mono uppercase tracking-wide text-slate-400">SKU #{p.codigo}</span>
+
+                    <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-[13px] text-slate-600">
+                      <div className="space-y-0.5">
+                        <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Peso</dt>
+                        <dd className="text-sm text-slate-900">{formatPeso(p.peso, p.tipoPeso)}</dd>
+                      </div>
+                      <div className="space-y-0.5">
+                        <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Faixa etária</dt>
+                        <dd className="text-sm text-slate-900">{p.faixaEtariaNome}</dd>
+                      </div>
+                      <div className="space-y-0.5">
+                        <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Sabores</dt>
+                        <dd className="text-sm text-slate-900">{p.sabores || "Não informado"}</dd>
+                      </div>
+                      <div className="space-y-0.5">
+                        <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Porte indicado</dt>
+                        <dd className="text-sm text-slate-900">{portes}</dd>
+                      </div>
+                      <div className="col-span-2 space-y-0.5">
+                        <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Categoria</dt>
+                        <dd className="text-sm text-slate-900">{p.tipoProdutoNome}</dd>
+                      </div>
+                    </dl>
+
+                    <div className="mt-auto flex items-center justify-between gap-3">
+                      <div>
+                        <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Preço</span>
+                        <p className="text-xl font-semibold text-slate-900">{precoFormatado}</p>
+                      </div>
+                      <button
+                        className="inline-flex items-center gap-1.5 rounded-full bg-indigo-600 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition-colors duration-200 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                        onClick={() => handleAdd(p)}
+                      >
+                        <ShoppingCart className="h-3.5 w-3.5" aria-hidden="true" />
+                        Adicionar
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+
+          <nav
+            className="flex flex-col gap-3 rounded-2xl border border-indigo-100 bg-white/80 px-5 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+            aria-label="Paginação do catálogo"
+          >
+            <p className="text-sm text-slate-600">
+              Mostrando{" "}
+              <span className="font-semibold text-slate-900">
+                {showingStart}-{showingEnd}
+              </span>{" "}
+              de{" "}
+              <span className="font-semibold text-slate-900">{safeTotalItems}</span>{" "}
+              produtos
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setPage(Math.max(safePage - 1, 1))}
+                disabled={!canGoPrev}
+                className="inline-flex items-center gap-2 rounded-full border border-indigo-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400 disabled:hover:bg-transparent"
+              >
+                Anterior
+              </button>
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Página {safePage} de {displayTotalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage(Math.min(safePage + 1, displayTotalPages))}
+                disabled={!canGoNext}
+                className="inline-flex items-center gap-2 rounded-full border border-indigo-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400 disabled:hover:bg-transparent"
+              >
+                Próxima
+              </button>
+            </div>
+          </nav>
+        </div>
+      ) : (
+        <div className="rounded-3xl border border-dashed border-slate-200 bg-white px-8 py-16 text-center text-slate-500 shadow-sm">
+          Nenhum produto encontrado com os filtros selecionados.
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/views/Produtos.tsx
+++ b/frontend/src/views/Produtos.tsx
@@ -25,6 +25,16 @@ type ProdutoOpcao = {
   nome: string;
 };
 
+type ProdutosPagedResponse = {
+  items?: Produto[] | null;
+  page?: number;
+  pageSize?: number;
+  totalItems?: number;
+  totalPages?: number;
+};
+
+type ProdutosListResponse = Produto[] | ProdutosPagedResponse;
+
 type PorteSelectOption = {
   value: string;
   label: string;
@@ -260,7 +270,18 @@ export default function Produtos() {
     return `${before}${separator}${after}`;
   };
 
-  const loadProdutos = async () => setProdutos((await api.get("/produtos")).data);
+  const loadProdutos = async () => {
+    const response = await api.get<ProdutosListResponse>("/produtos");
+    const data = response.data;
+
+    if (Array.isArray(data)) {
+      setProdutos(data);
+      return;
+    }
+
+    const items = Array.isArray(data?.items) ? data.items : [];
+    setProdutos(items);
+  };
   const resetFormCampos = () => {
     setProdutoEmEdicao(null);
     setCodigo("");


### PR DESCRIPTION
## Summary
- normalize the /produtos fetch logic to accept either raw arrays or paged results
- ensure the products management view renders safely when the API returns paginated data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d36dab1124832d93b0d06c5365ff98