### PR TITLE
Add production Docker images for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,62 @@ cp .env.example .env
 npm run dev
 ```
 Acesse `http://localhost:5173`.
+
+## 3) Conteinerização e deploy (Docker + Azure Container Registry)
+
+### Backend (.NET 9)
+
+1. Entre na pasta do backend e gere a imagem multi-stage otimizada para produção:
+
+   ```bash
+   cd backend
+   docker build -t <registry>.azurecr.io/product-shop-api:1.0.0 .
+   ```
+
+2. Ao executar o container, informe as configurações obrigatórias via variáveis de ambiente:
+
+   ```bash
+   docker run -it --rm -p 8080:8080 \
+     -e ConnectionStrings__Postgres="Host=<host>;Port=5432;Database=<db>;Username=<user>;Password=<password>" \
+     -e Auth__TenantId="<tenant-guid>" \
+     -e Auth__Audience="api://<api-app-id>" \
+     -e Auth__ClientId="<api-client-id>" \
+     -e Cors__Origins="https://app.suaempresa.com" \
+     <registry>.azurecr.io/product-shop-api:1.0.0
+   ```
+
+   A aplicação escuta na porta `8080` dentro do container. Garanta que o serviço de banco de dados esteja acessível a partir do cluster/host que executará a imagem.
+
+### Frontend (React + Vite)
+
+1. Gere o build estático com Node.js e sirva com NGINX:
+
+   ```bash
+   cd frontend
+   docker build -t <registry>.azurecr.io/product-shop-web:1.0.0 .
+   ```
+
+   Use `--build-arg VITE_API_BASE_URL="https://sua-api.azurewebsites.net"` caso precise sobrescrever a URL consumida pelo frontend no momento do build.
+
+2. Para validar localmente:
+
+   ```bash
+   docker run -it --rm -p 8081:80 <registry>.azurecr.io/product-shop-web:1.0.0
+   ```
+
+   O NGINX já possui configuração para aplicações SPA (rota fallback para `index.html`) e um endpoint de health check em `/healthz`.
+
+### Publicação no Azure Container Registry (ACR)
+
+```bash
+az login
+az acr login --name <registry>
+
+# Backend
+docker push <registry>.azurecr.io/product-shop-api:1.0.0
+
+# Frontend
+docker push <registry>.azurecr.io/product-shop-web:1.0.0
+```
+
+Substitua `<registry>` pelo nome do ACR (sem o sufixo `.azurecr.io`). Depois do push você pode usar os repositórios diretamente em Web App for Containers, Azure Container Apps, AKS, etc., configurando as mesmas variáveis de ambiente utilizadas durante o teste local.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,10 @@
+**/bin
+**/obj
+**/.vs
+Dockerfile
+README.md
+.git
+.gitignore
+.vscode
+.vs
+*.user

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,35 @@
+# Build and publish the ASP.NET Core API
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Copy project files individually to leverage Docker layer caching
+COPY src/PremieRpet.Shop.sln ./
+COPY src/PremieRpet.Shop.Domain/PremieRpet.Shop.Domain.csproj PremieRpet.Shop.Domain/
+COPY src/PremieRpet.Shop.Application/PremieRpet.Shop.Application.csproj PremieRpet.Shop.Application/
+COPY src/PremieRpet.Shop.Infrastructure/PremieRpet.Shop.Infrastructure.csproj PremieRpet.Shop.Infrastructure/
+COPY src/PremieRpet.Shop.Api/PremieRpet.Shop.Api.csproj PremieRpet.Shop.Api/
+
+RUN dotnet restore PremieRpet.Shop.Api/PremieRpet.Shop.Api.csproj
+
+# Copy the remaining source code and publish
+COPY src/ ./
+RUN dotnet publish PremieRpet.Shop.Api/PremieRpet.Shop.Api.csproj \
+    -c Release \
+    -o /app/publish \
+    /p:UseAppHost=false
+
+# Final runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+# ASP.NET Core configuration for containerized production workloads
+ENV ASPNETCORE_ENVIRONMENT=Production \
+    ASPNETCORE_URLS=http://+:8080 \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+EXPOSE 8080
+
+COPY --from=build /app/publish ./
+
+ENTRYPOINT ["dotnet", "PremieRpet.Shop.Api.dll"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.vscode
+.git
+.gitignore
+coverage
+*.local
+*.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1 - install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Stage 2 - build the production bundle
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+RUN npm run build
+
+# Stage 3 - serve the static bundle with NGINX
+FROM nginx:1.27-alpine AS runner
+
+# Copy a custom nginx configuration tailored for single page applications
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy build artefacts
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s CMD wget --no-verbose --spider http://localhost/healthz || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen       80;
+    server_name  _;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    # Allow container orchestrators to probe application health
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively while keeping index.html always fresh
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the .NET API along with a Docker ignore file configured for production builds
- add a Node/NGINX-based Docker image to serve the Vite frontend and configure static asset caching and health checks
- document how to build, run, and publish both images to Azure Container Registry, including required environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f57a55fc832daa0fd721b8eb6811