### PR TITLE
Avoid handling MSAL redirect when hash empty

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,9 @@ const router = createBrowserRouter([
   await pca.initialize();
 
   try {
-    await pca.handleRedirectPromise();
+    if (window.location.hash) {
+      await pca.handleRedirectPromise();
+    }
   } catch (e: any) {
     if (e?.errorCode !== "hash_empty_error") {
       console.error("MSAL redirect error:", e);


### PR DESCRIPTION
## Summary
- skip calling `handleRedirectPromise` when there is no hash in the URL to avoid spurious hash_empty_error warnings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e1e7b43c832da1d2902ec1481716