### PR TITLE
Expose order-creation availability and enforce monthly deadline

### DIFF
--- a/backend/src/PremieRpet.Shop.Application/DTOs/PedidoResumoMensalDto.cs
+++ b/backend/src/PremieRpet.Shop.Application/DTOs/PedidoResumoMensalDto.cs
@@ -10,5 +10,7 @@ public sealed record PedidoResumoMensalDto(
     int PedidosUtilizados,
     int QuantidadeMinimaPadrao,
     int EditWindowOpeningDay,
-    int EditWindowClosingDay
+    int EditWindowClosingDay,
+    bool PodeCriarPedido,
+    string? MotivoBloqueioCriacaoPedido
 );

--- a/backend/src/PremieRpet.Shop.Application/UseCases/PedidoService.cs
+++ b/backend/src/PremieRpet.Shop.Application/UseCases/PedidoService.cs
@@ -211,7 +211,7 @@ public sealed class PedidoService : IPedidoService
         return agrupados;
     }
 
-    private bool EstaDentroJanelaEdicao(DateTimeOffset momentoUtc)
+    private static DateTimeOffset ConverterParaHorarioLocal(DateTimeOffset momentoUtc)
     {
         DateTimeOffset referencia = momentoUtc;
         foreach (var tzId in TimeZoneCandidates)
@@ -230,9 +230,25 @@ public sealed class PedidoService : IPedidoService
             }
         }
 
+        return referencia;
+    }
+
+    private bool EstaDentroJanelaEdicao(DateTimeOffset momentoUtc)
+    {
+        var referencia = ConverterParaHorarioLocal(momentoUtc);
+
         var dia = referencia.Day;
         return dia >= _settings.EditWindowOpeningDay && dia <= _settings.EditWindowClosingDay;
     }
+
+    private bool EstaDentroPrazoSolicitacaoPedido(DateTimeOffset momentoUtc)
+    {
+        var referencia = ConverterParaHorarioLocal(momentoUtc);
+        return referencia.Day <= _settings.EditWindowClosingDay;
+    }
+
+    private string ObterMensagemPrazoSolicitacaoEncerrado()
+        => $"Não é mais possível realizar pedidos para este mês. O prazo de fechamento encerrou no dia {_settings.EditWindowClosingDay}.";
 
     private static DateTimeOffset InicioMesUtc(int ano, int mes)
     {
@@ -259,6 +275,9 @@ public sealed class PedidoService : IPedidoService
             ?? throw new InvalidOperationException("Empresa inválida.");
 
         var agora = DateTimeOffset.UtcNow;
+        if (!EstaDentroPrazoSolicitacaoPedido(agora))
+            throw new InvalidOperationException(ObterMensagemPrazoSolicitacaoEncerrado());
+
         var perfil = await _usuarios.GarantirCpfAsync(usuarioEmail, usuarioMicrosoftId, dto.Cpf, usuarioNome, ct);
         var usuarioSemLimite = await UsuarioIgnoraLimitePesoAsync(perfil.Id, ct);
         var pesoAcumulado = await PesoAcumuladoMesEmKgAsync(perfil.Id, agora, ct);
@@ -856,6 +875,9 @@ public sealed class PedidoService : IPedidoService
             ? await UsuarioIgnoraLimitePesoAsync(usuarioResumoId.Value, ct)
             : false;
 
+        var agora = DateTimeOffset.UtcNow;
+        var podeCriarPedido = isAdmin || EstaDentroPrazoSolicitacaoPedido(agora);
+
         return new PedidoResumoMensalDto(
             usuarioSemLimite ? 0 : _limiteKgMes,
             totalKg,
@@ -866,7 +888,9 @@ public sealed class PedidoService : IPedidoService
             pedidosUtilizados,
             _quantidadeMinimaPadrao,
             _settings.EditWindowOpeningDay,
-            _settings.EditWindowClosingDay
+            _settings.EditWindowClosingDay,
+            podeCriarPedido,
+            podeCriarPedido ? null : ObterMensagemPrazoSolicitacaoEncerrado()
         );
     }
 

--- a/frontend/src/hooks/usePedidosConfig.tsx
+++ b/frontend/src/hooks/usePedidosConfig.tsx
@@ -98,6 +98,8 @@ type PedidosConfigContextValue = {
   editWindowClosingDay: number;
   loading: boolean;
   error: string | null;
+  podeCriarPedido: boolean;
+  motivoBloqueioCriacaoPedido: string | null;
   refresh: () => Promise<void>;
 };
 
@@ -110,6 +112,8 @@ export function PedidosConfigProvider({ children }: { children: ReactNode }) {
   const [editWindowClosingDay, setEditWindowClosingDay] = useState(20);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [podeCriarPedido, setPodeCriarPedido] = useState(true);
+  const [motivoBloqueioCriacaoPedido, setMotivoBloqueioCriacaoPedido] = useState<string | null>(null);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -134,6 +138,11 @@ export function PedidosConfigProvider({ children }: { children: ReactNode }) {
     setMinQtyPadrao(normalizeMinQty(data?.quantidadeMinimaPadrao));
     setEditWindowOpeningDay(openingDay);
     setEditWindowClosingDay(closingDay);
+    setPodeCriarPedido(data?.podeCriarPedido !== false);
+    const motivoBloqueio = typeof data?.motivoBloqueioCriacaoPedido === "string" && data.motivoBloqueioCriacaoPedido.trim()
+      ? data.motivoBloqueioCriacaoPedido.trim()
+      : null;
+    setMotivoBloqueioCriacaoPedido(motivoBloqueio);
     setError(null);
   }, []);
 
@@ -144,6 +153,8 @@ export function PedidosConfigProvider({ children }: { children: ReactNode }) {
     setMinQtyPadrao(1);
     setEditWindowOpeningDay(15);
     setEditWindowClosingDay(20);
+    setPodeCriarPedido(true);
+    setMotivoBloqueioCriacaoPedido(null);
   }, []);
 
   const refresh = useCallback(async () => {
@@ -170,6 +181,8 @@ export function PedidosConfigProvider({ children }: { children: ReactNode }) {
       editWindowClosingDay,
       loading,
       error,
+      podeCriarPedido,
+      motivoBloqueioCriacaoPedido,
       refresh,
     }),
     [
@@ -179,6 +192,8 @@ export function PedidosConfigProvider({ children }: { children: ReactNode }) {
       editWindowClosingDay,
       loading,
       error,
+      podeCriarPedido,
+      motivoBloqueioCriacaoPedido,
       refresh,
     ],
   );

--- a/frontend/src/types/pedidos.ts
+++ b/frontend/src/types/pedidos.ts
@@ -73,6 +73,8 @@ type PedidoResumoMensal = {
   quantidadeMinimaPadrao: number;
   editWindowOpeningDay: number;
   editWindowClosingDay: number;
+  podeCriarPedido: boolean;
+  motivoBloqueioCriacaoPedido: string | null;
 };
 
 export type {

--- a/frontend/src/views/Checkout.tsx
+++ b/frontend/src/views/Checkout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import api from "../lib/api";
 import { useCart } from "../cart/CartContext";
 import { useNavigate } from "react-router-dom";
@@ -17,7 +17,13 @@ type Empresa = {
 export default function Checkout() {
   const { items, totalValor, totalPesoKg, clear, anyBelowMinimum } = useCart();
   const pesoTotalFormatado = formatPeso(totalPesoKg, "kg", { unit: "kg" });
-  const { limitKg: limiteMensalKg, loading: limiteLoading, error: limiteErro } = usePedidosConfig();
+  const {
+    limitKg: limiteMensalKg,
+    loading: limiteLoading,
+    error: limiteErro,
+    podeCriarPedido,
+    motivoBloqueioCriacaoPedido,
+  } = usePedidosConfig();
   const [empresas, setEmpresas] = useState<Empresa[]>([]);
   const [empresaId, setEmpresaId] = useState<string>("");
   const [loading, setLoading] = useState(false);
@@ -36,6 +42,7 @@ export default function Checkout() {
   const limiteMensalFormatado = usuarioSemLimite
     ? "Sem limite"
     : (limiteMensalKg > 0 ? formatPeso(limiteMensalKg, "kg", { unit: "kg" }) : "Não configurado");
+
 
   useEffect(() => {
     let alive = true;
@@ -140,7 +147,8 @@ export default function Checkout() {
     loadingPerfil ||
     !empresaId ||
     anyBelowMinimum ||
-    (!cpfBloqueado && !isValidCpf(cpf));
+    (!cpfBloqueado && !isValidCpf(cpf)) ||
+    !podeCriarPedido;
 
   return (
     <div className="space-y-6">
@@ -257,6 +265,12 @@ export default function Checkout() {
               <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">{limiteErro}</div>
             )}
 
+            {!podeCriarPedido && motivoBloqueioCriacaoPedido && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                {motivoBloqueioCriacaoPedido}
+              </div>
+            )}
+
             {!usuarioSemLimite && limiteMensalKg > 0 && totalPesoKg > limiteMensalKg && (
               <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
                 Atenção: seu carrinho tem {pesoTotalFormatado}. O limite mensal é {limiteMensalFormatado}.
@@ -276,7 +290,7 @@ export default function Checkout() {
           onClick={enviar}
           disabled={disableFinalize}
           className="inline-flex items-center justify-center rounded-full bg-[#FF6900] px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#FF6900]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#FF6900]/40 disabled:cursor-not-allowed disabled:opacity-60"
-          title={anyBelowMinimum ? "Há itens abaixo da quantidade mínima." : ""}
+          title={!podeCriarPedido ? (motivoBloqueioCriacaoPedido ?? "") : (anyBelowMinimum ? "Há itens abaixo da quantidade mínima." : "")}
         >
           {loading ? "Enviando..." : "Finalizar solicitação"}
         </button>


### PR DESCRIPTION
### Motivation

- Prevent creating new orders after the monthly closing day and surface that availability to the frontend. 

### Description

- Added `PodeCriarPedido` and `MotivoBloqueioCriacaoPedido` to the monthly summary DTO (`PedidoResumoMensalDto`) so the API returns whether order creation is allowed and an optional reason. 
- Implemented timezone-aware helper (`ConverterParaHorarioLocal`) and new checks `EstaDentroPrazoSolicitacaoPedido` plus `ObterMensagemPrazoSolicitacaoEncerrado` in `PedidoService`, and enforced the closing-day deadline in `CriarPedidoAsync`. 
- Updated the summary response assembly to compute `podeCriarPedido` and include the blocking message when appropriate. 
- Frontend: extended the `PedidoResumoMensal` type, updated `usePedidosConfig` to store `podeCriarPedido` and `motivoBloqueioCriacaoPedido`, and changed `Checkout` to disable finalization and show the blocking message when order creation is disallowed.

### Testing

- Ran backend build and tests with `dotnet build` and `dotnet test`, which completed successfully. 
- Ran frontend type check/build with `npm run build` (TypeScript compilation) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08e6dcf98832dbf2089d71157a2c9)