### PR TITLE
Ignora erro 401 transitório no carregamento de configurações de pedidos (remove aviso no carrinho)

### DIFF
--- a/frontend/src/hooks/usePedidosConfig.tsx
+++ b/frontend/src/hooks/usePedidosConfig.tsx
@@ -91,6 +91,15 @@ function extractErrorMessage(err: unknown): string {
   return "Não foi possível carregar as configurações de pedidos.";
 }
 
+function isUnauthorizedError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    typeof (err as { response?: { status?: unknown } }).response?.status === "number" &&
+    (err as { response?: { status?: number } }).response?.status === 401
+  );
+}
+
 type PedidosConfigContextValue = {
   limitKg: number;
   minQtyPadrao: number;
@@ -148,7 +157,13 @@ export function PedidosConfigProvider({ children }: { children: ReactNode }) {
 
   const applyError = useCallback((err: unknown) => {
     if (!isMountedRef.current) return;
-    setError(extractErrorMessage(err));
+
+    if (isUnauthorizedError(err)) {
+      setError(null);
+    } else {
+      setError(extractErrorMessage(err));
+    }
+
     setLimitKg(0);
     setMinQtyPadrao(1);
     setEditWindowOpeningDay(15);


### PR DESCRIPTION
### Motivation
- Evitar que um `401` transitório durante a inicialização da sessão mostre o alerta amarelo no carrinho ao entrar no sistema pela primeira vez, mantendo valores padrão até a autenticação estabilizar.

### Description
- Adicionado o helper `isUnauthorizedError` em `frontend/src/hooks/usePedidosConfig.tsx` e alterado `applyError` para limpar `error` quando o erro for `401`, mantendo o comportamento atual para outros erros e preservando os defaults de configuração.

### Testing
- Executado `cd frontend && npm run build`, que concluiu com sucesso.;
- Iniciado o servidor de desenvolvimento (`npm run dev`) e verificado que a aplicação sobe corretamente.;
- Rodado um script Playwright que carregou `http://127.0.0.1:4173` e capturou um screenshot para validação visual, sem reproduzir o alerta 401.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1782ceea4832da6942c96f39cf3f4)