### PR TITLE
Normalize MSAL redirect URI to current origin

### DIFF
--- a/frontend/src/auth/msal.ts
+++ b/frontend/src/auth/msal.ts
@@ -12,9 +12,28 @@ function requireEnv(name: string, value: string | undefined) {
   return value;
 }
 
+function resolveRedirectUri(configuredRedirectUri: string) {
+  if (typeof window === "undefined") {
+    return configuredRedirectUri;
+  }
+
+  const currentOrigin = window.location.origin;
+
+  try {
+    const parsedRedirectUri = new URL(configuredRedirectUri);
+    if (parsedRedirectUri.origin === currentOrigin) {
+      return configuredRedirectUri;
+    }
+
+    return `${currentOrigin}${parsedRedirectUri.pathname}${parsedRedirectUri.search}${parsedRedirectUri.hash}`;
+  } catch {
+    return `${currentOrigin}/login`;
+  }
+}
+
 const TENANT = requireEnv('VITE_AAD_TENANT_ID', import.meta.env.VITE_AAD_TENANT_ID);
 const CLIENT = requireEnv('VITE_AAD_CLIENT_ID', import.meta.env.VITE_AAD_CLIENT_ID);
-const REDIRECT = requireEnv('VITE_REDIRECT_URI', import.meta.env.VITE_REDIRECT_URI);
+const REDIRECT = resolveRedirectUri(requireEnv('VITE_REDIRECT_URI', import.meta.env.VITE_REDIRECT_URI));
 const SCOPE = requireEnv('VITE_API_SCOPE', import.meta.env.VITE_API_SCOPE);
 
 export const msalConfig: Configuration = {


### PR DESCRIPTION
### Motivation
- After migrating the app domain, `VITE_REDIRECT_URI` could still contain the old origin and MSAL redirects would send users back to the old host during login/logout.

### Description
- Added `resolveRedirectUri` in `frontend/src/auth/msal.ts` to normalize the configured `VITE_REDIRECT_URI` to the current browser origin (`window.location.origin`) while preserving path/query/hash.
- Replaced the static `REDIRECT` with the resolved value and used it for both `redirectUri` and `postLogoutRedirectUri` in `msalConfig`.
- The resolver returns the configured value on server-side, and falls back to ``${window.location.origin}/login`` if the configured URL is malformed.

### Testing
- Ran a production frontend build with `npm --prefix frontend run build`, which completed successfully.
- The build confirms the TypeScript/MSAL configuration compiles and the updated file `frontend/src/auth/msal.ts` is included in the bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1899c38dc832db404cf6271ed095e)